### PR TITLE
Fixup/datasets (and review)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,9 +11,6 @@ Authors@R: c(
            comment = c(ORCID = "0000-0002-8147-1239")),
     person("Max", "Moldovan", , "max.moldovan@adelaide.edu.au", role = "aut",
            comment = c(ORCID = "0000-0001-9680-8474")),
-    person("Curtin University", role = "cph",
-           comment = c("Provided support through Adam Sparks's time.",  ROR = "02n415q13")),
-    person("Adelaide University", role = "cph", ROR = "028g18b61"),
     person("Grains Research and Development Corporation", role = c("fnd", "cph"),
            comment = c("GRDC Project CUR2210-005OPX (AAGI-CU), UOA2301-005OPX (AAGI-AU)", ROR = "02xwr1996"))
   )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nert
 Title: An API Client for TERN Data
-Version: 1.0.0
+Version: 1.1.0
 Authors@R: c(
     person("Adam H.", "Sparks", , "adamhsparks@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0002-0061-8359")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,8 +13,9 @@ Authors@R: c(
            comment = c(ORCID = "0000-0001-9680-8474")),
     person("Curtin University", role = "cph",
            comment = c("Provided support through Adam Sparks's time.",  ROR = "02n415q13")),
+    person("Adelaide University", role = "cph", ROR = "028g18b61"),
     person("Grains Research and Development Corporation", role = c("fnd", "cph"),
-           comment = c("GRDC Project CUR2210-005OPX (AAGI-CU)", ROR = "02xwr1996"))
+           comment = c("GRDC Project CUR2210-005OPX (AAGI-CU), UOA2301-005OPX (AAGI-AU)", ROR = "02xwr1996"))
   )
 Description: Provides access to Australia's TERN (Terrestrial Ecosystem
     Research Network) data through the API, <https://www.tern.org.au/>.

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
 YEAR: 2024
-COPYRIGHT HOLDER: nert authors
+COPYRIGHT HOLDER: Grains Research and Development Corporation, Adelaide University, Curtin University, University of Queensland

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
 YEAR: 2024
-COPYRIGHT HOLDER: Grains Research and Development Corporation, Adelaide University, Curtin University, University of Queensland
+COPYRIGHT HOLDER: Grains Research and Development Corporation

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
 # MIT License
 
-Copyright (c) 2024 nert authors
+Copyright (c) 2024 Grains Research and Development Corporation, Adelaide 
+University, Curtin University, University of Queensland
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,6 @@
 # MIT License
 
-Copyright (c) 2024 Grains Research and Development Corporation, Adelaide 
-University, Curtin University, University of Queensland
+Copyright (c) 2024 Grains Research and Development Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,20 @@
+# nert 1.1.0
+
+Updated version, fixing a number of issues with the TERN dataset retrieval.
+
+- `read_smips()` now tests the correct day when validating the date for
+  a requested raster.
+- `read_phenology()` now provides access to all of the phenology datasets
+  available on the TERN Data Portal, including the monthly SGS/PGS/EGS.
+- `read_slga()` provides access to an additional six datasets (CEC,ECE,
+  AVP,PTO,DUL,L15), and also allows the user to pull the 05 and 95
+  percentile limits for the 95% confidence interval.
+- `read_asc()` now provides access to its data and confusion index rasters
+  using a consistent interface with the rest of the `read_*()` functions.
+- Documentation for the functions and their TERN datasets has been
+  reviewed and improved.
+
+
 # nert 1.0.0
 
 First stable release.  The package has matured through the 0.0.x

--- a/R/collect_tern_data.R
+++ b/R/collect_tern_data.R
@@ -17,9 +17,9 @@
 #'   coordinate columns named `lon`/`lat` or `x`/`y`.  Takes precedence
 #'   over `lon`/`lat` when supplied.
 #' @param datasets `character` vector of dataset aliases to collect.
-#'   Default: all 14 datasets (SMIPS, ASC, AET, AWC, CLY, SND, SLT, BDW,
-#'   PHC, PHW, NTO, SOILDIV, CANOPY, PHENOLOGY).  Use `NULL` or `"all"`
-#'   for all datasets.
+#'   Default: all 20 datasets (SMIPS, ASC, AET, AWC, CLY, SND, SLT, BDW,
+#'   PHC, PHW, NTO, AVP, PTO, CEC, ECE, DUL, L15, SOILDIV, CANOPY, PHENOLOGY).
+#'   Use `NULL` or `"all"` for all datasets.
 #' @param depth For SLGA datasets: depth interval (default `"all"`).
 #'   Options: `"000_005"`, `"005_015"`, `"015_030"`, `"030_060"`,
 #'   `"060_100"`, `"100_200"`, or `"all"` for all six GlobalSoilMap depths.
@@ -112,11 +112,9 @@ collect_tern_data <- function(
   na.rm = FALSE
 ) {
   coords_df <- .parse_coordinates(lon, lat, xy)
-  n_loc     <- nrow(coords_df)
-
+  n_loc <- nrow(coords_df)
   dates <- .parse_date_range(date_range)
-  n_dt  <- length(dates)
-
+  n_dt <- length(dates)
   datasets <- .normalise_datasets(datasets)
 
   if (verbose) {
@@ -127,6 +125,12 @@ collect_tern_data <- function(
     )
   }
 
+  #FIXME: Russell (08/06): Note that the canopy height data is returned
+  #  in the Australian Albers EPSG:3577 coordinate reference system,
+  #  rather than WGS84/EPSG:4326. This aggregation might not work when
+  #  the user includes the canopy height data for retrieval. We might
+  #  have to add some specific logic to .parse_coordinates() to handle
+  #  this case for us.
   pts <- terra::vect(
     as.matrix(coords_df[, c("lon", "lat")]),
     type = "points",
@@ -139,8 +143,8 @@ collect_tern_data <- function(
 
   out <- data.table::data.table(
     date = rep(dates, each = n_loc),
-    lon  = rep(coords_df$lon, times = n_dt),
-    lat  = rep(coords_df$lat, times = n_dt)
+    lon = rep(coords_df$lon, times = n_dt),
+    lat = rep(coords_df$lat, times = n_dt)
   )
 
   for (wi in work_items) {
@@ -178,9 +182,6 @@ collect_tern_data <- function(
   out[]
 }
 
-# -----------------------------------------------------------------------------
-# Coordinate / date / dataset parsers
-# -----------------------------------------------------------------------------
 
 #' Normalise coordinate input
 #'
@@ -228,6 +229,12 @@ collect_tern_data <- function(
   if (any(is.na(coords$lon) | is.na(coords$lat))) {
     cli::cli_abort("Coordinates must not be {.code NA}.")
   }
+
+  #FIXME: Russell (08/06): Surely we can be more specific than this. They
+  #  are strictly Australian datasets in decimal degrees Northing, so really
+  #  anything outside of -44 < lat < -10 ish, and 112 < lon < 154 ish is
+  #  going to be out-of-bounds (in WGS84 at least--not sure if/how that
+  #  changes for the canopy height dataset in Aust Albers coordinates).
   if (any(coords$lon < -180 | coords$lon > 180 |
             coords$lat < -90  | coords$lat > 90)) {
     cli::cli_abort(
@@ -236,6 +243,7 @@ collect_tern_data <- function(
   }
   coords
 }
+
 
 #' Normalise a date_range argument
 #'
@@ -273,8 +281,8 @@ collect_tern_data <- function(
 .normalise_datasets <- function(datasets) {
   all_aliases <- c(
     "SMIPS", "ASC", "AET",
-    "AWC", "CLY", "SND", "SLT", "BDW", "PHC", "PHW", "NTO",
-    "SOILDIV", "CANOPY", "PHENOLOGY"
+    "AWC", "CLY", "SND", "SLT", "BDW", "PHC", "PHW", "NTO", "AVP", "PTO",
+    "CEC", "ECE", "DUL", "L15", "SOILDIV", "CANOPY", "PHENOLOGY"
   )
   if (is.null(datasets) ||
         (length(datasets) == 1L && identical(datasets, "all"))) {
@@ -300,9 +308,6 @@ collect_tern_data <- function(
   datasets
 }
 
-# -----------------------------------------------------------------------------
-# Work-item planner: one item per COG fetch
-# -----------------------------------------------------------------------------
 
 #' Plan the list of COG fetches
 #'
@@ -319,20 +324,22 @@ collect_tern_data <- function(
 #' @param datasets Normalised alias vector.
 #' @param dates Resolved `Date` vector.
 #' @param depth SLGA depth selector.
-#' @param stat SLGA stat selector (`"EV"` or `"CI"`).
+#' @param stat SLGA stat selector (`"EV"`, `"05"` or `"95"`).
 #' @param smips_collection SMIPS collection selector.
 #' @returns A list of work-item lists.
 #' @autoglobal
 #' @dev
 .build_work_items <- function(datasets, dates, depth, stat, smips_collection) {
-  slga_aliases <- c("AWC", "CLY", "SND", "SLT", "BDW", "PHC", "PHW", "NTO")
+  slga_aliases <- c(
+    "AWC", "CLY", "SND", "SLT", "BDW", "PHC", "PHW", "NTO", "AVP", "PTO",
+    "CEC", "ECE", "DUL", "L15"
+  )
   slga_depths  <- c("000_005", "005_015", "015_030",
                     "030_060", "060_100", "100_200")
   smips_variants <- c("totalbucket", "SMindex", "bucket1",
                       "bucket2", "deepD", "runoff")
 
   items <- list()
-
   for (ds in datasets) {
     if (ds == "SMIPS") {
       variants <- if (smips_collection == "all") {
@@ -344,24 +351,24 @@ collect_tern_data <- function(
         col <- paste0("SMIPS_", v)
         for (i in seq_along(dates)) {
           items[[length(items) + 1L]] <- list(
-            ds       = "SMIPS",
-            type     = "numeric",
-            cols     = col,
+            ds = "SMIPS",
+            type = "numeric",
+            cols = col,
             date_idx = i,
-            args     = list(date = dates[i], collection = v),
-            label    = sprintf("SMIPS %s %s", v, format(dates[i], "%Y-%m-%d"))
+            args = list(date = dates[i], collection = v),
+            label = sprintf("SMIPS %s %s", v, format(dates[i], "%Y-%m-%d"))
           )
         }
       }
     } else if (ds == "AET") {
       for (i in seq_along(dates)) {
         items[[length(items) + 1L]] <- list(
-          ds       = "AET",
-          type     = "numeric",
-          cols     = "AET",
+          ds = "AET",
+          type = "numeric",
+          cols = "AET",
           date_idx = i,
-          args     = list(date = dates[i]),
-          label    = sprintf("AET %s", format(dates[i], "%Y-%m-%d"))
+          args = list(date = dates[i]),
+          label = sprintf("AET %s", format(dates[i], "%Y-%m-%d"))
         )
       }
     } else if (ds %in% slga_aliases) {
@@ -369,42 +376,42 @@ collect_tern_data <- function(
       for (d in depths) {
         col <- if (depth == "all") paste0(ds, "_", d) else ds
         items[[length(items) + 1L]] <- list(
-          ds       = ds,
-          type     = "numeric",
-          cols     = col,
+          ds = ds,
+          type = "numeric",
+          cols = col,
           date_idx = NA_integer_,
-          args     = list(depth = d, collection = stat),
-          label    = sprintf("%s depth %s (static)", ds, d)
+          args = list(depth = d, collection = stat),
+          label = sprintf("%s depth %s (static)", ds, d)
         )
       }
     } else if (ds == "ASC") {
       items[[length(items) + 1L]] <- list(
-        ds       = "ASC",
-        type     = "character",
-        cols     = "ASC",
+        ds = "ASC",
+        type = "character",
+        cols = "ASC",
         date_idx = NA_integer_,
-        args     = list(),
-        label    = "ASC (static)"
+        args = list(),
+        label = "ASC (static)"
       )
     } else if (ds == "PHENOLOGY") {
       phen_year <- as.integer(format(dates[1L], "%Y"))
       phen_year <- max(2003L, min(2018L, phen_year))
       items[[length(items) + 1L]] <- list(
-        ds       = "PHENOLOGY",
-        type     = "numeric",
-        cols     = "PHENOLOGY",
+        ds = "PHENOLOGY",
+        type = "numeric",
+        cols = "PHENOLOGY",
         date_idx = NA_integer_,
-        args     = list(year = phen_year),
-        label    = sprintf("PHENOLOGY year %d (static)", phen_year)
+        args = list(year = phen_year),
+        label = sprintf("PHENOLOGY year %d (static)", phen_year)
       )
     } else {
       items[[length(items) + 1L]] <- list(
-        ds       = ds,
-        type     = "numeric",
-        cols     = ds,
+        ds = ds,
+        type = "numeric",
+        cols = ds,
         date_idx = NA_integer_,
-        args     = list(),
-        label    = sprintf("%s (static)", ds)
+        args = list(),
+        label = sprintf("%s (static)", ds)
       )
     }
   }
@@ -412,9 +419,6 @@ collect_tern_data <- function(
   items
 }
 
-# -----------------------------------------------------------------------------
-# Per-COG extractor: one read_tern + one terra::extract per work item
-# -----------------------------------------------------------------------------
 
 #' Fetch one work item and write its values into the output table by reference.
 #'
@@ -429,7 +433,6 @@ collect_tern_data <- function(
 #' @param n_dt Number of dates.
 #' @param n_loc Number of locations.
 #' @param api_key TERN API key.
-#' @returns `invisible(NULL)`.
 #' @autoglobal
 #' @dev
 .fill_work_item <- function(out, wi, pts, n_dt, n_loc, api_key) {
@@ -483,16 +486,13 @@ collect_tern_data <- function(
     out[, (wi$cols[1L]) := rep(v, times = n_dt)]
   } else {
     row_start <- (wi$date_idx - 1L) * n_loc + 1L
-    row_end   <- wi$date_idx * n_loc
+    row_end <- wi$date_idx * n_loc
     out[seq.int(row_start, row_end), (wi$cols[1L]) := v]
   }
 
   invisible(NULL)
 }
 
-# -----------------------------------------------------------------------------
-# Pretty datasets-table for verbose output
-# -----------------------------------------------------------------------------
 
 #' Print the user-facing datasets-table summarising what will be fetched.
 #'
@@ -505,69 +505,98 @@ collect_tern_data <- function(
 #' @dev
 .print_datasets_table <- function(datasets, depth, smips_collection, stat) {
   dataset_info <- list(
-    SMIPS     = list(id = "TERN/d1995ee8", temporal = "Daily",
-                     resolution = "1 km",
-                     description = "Soil Moisture Integration & Prediction System"),
-    ASC       = list(id = "TERN/15728dba", temporal = "Static",
-                     resolution = "90 m",
-                     description = "Australian Soil Classification (soil order)"),
-    AET       = list(id = "TERN/9fefa68b", temporal = "Monthly",
-                     resolution = "30 m",
-                     description = "Actual Evapotranspiration (CMRSET)"),
-    AWC       = list(id = "TERN/482301c2", temporal = "Static",
-                     resolution = "90 m",
-                     description = "Available Water Capacity (SLGA)"),
-    CLY       = list(id = "TERN/slga_cly", temporal = "Static",
-                     resolution = "90 m",
-                     description = "Clay content % (SLGA)"),
-    SND       = list(id = "TERN/slga_snd", temporal = "Static",
-                     resolution = "90 m",
-                     description = "Sand content % (SLGA)"),
-    SLT       = list(id = "TERN/slga_slt", temporal = "Static",
-                     resolution = "90 m",
-                     description = "Silt content % (SLGA)"),
-    BDW       = list(id = "TERN/slga_bdw", temporal = "Static",
-                     resolution = "90 m",
-                     description = "Bulk Density whole soil (SLGA)"),
-    PHC       = list(id = "TERN/slga_phc", temporal = "Static",
-                     resolution = "90 m",
-                     description = "pH (CaCl2) soil acidity (SLGA)"),
-    PHW       = list(id = "TERN/slga_phw", temporal = "Static",
-                     resolution = "90 m",
-                     description = "pH (water) soil acidity (SLGA)"),
-    NTO       = list(id = "TERN/slga_nto", temporal = "Static",
-                     resolution = "90 m",
-                     description = "Total Nitrogen % weight (SLGA)"),
+    SMIPS = list(id = "TERN/d1995ee8", temporal = "Daily",
+                 resolution = "1 km",
+                 description = "Soil Moisture Integration & Prediction System"),
+    ASC = list(id = "TERN/15728dba", temporal = "Static",
+               resolution = "90 m",
+               description = "Australian Soil Classification (soil order)"),
+    AET = list(id = "TERN/9fefa68b", temporal = "Monthly",
+               resolution = "30 m",
+               description = "Actual Evapotranspiration via CMRSET"),
+    AWC = list(id = "TERN/482301c2", temporal = "Static",
+               resolution = "90 m",
+               description = "Available Water Capacity % (SLGA)"),
+    CLY = list(id = "TERN/f95dc442", temporal = "Static",
+               resolution = "90 m",
+               description = "Clay content % (SLGA)"),
+    SND = list(id = "TERN/4224ddff", temporal = "Static",
+               resolution = "90 m",
+               description = "Sand content % (SLGA)"),
+    SLT = list(id = "TERN/11375f04", temporal = "Static",
+               resolution = "90 m",
+               description = "Silt content % (SLGA)"),
+    BDW = list(id = "TERN/95978aec", temporal = "Static",
+               resolution = "90 m",
+               description = "Bulk Density whole earth (g/cm3) (SLGA)"),
+    PHC = list(id = "TERN/258afc98", temporal = "Static",
+               resolution = "90 m",
+               description = "pH (CaCl2) (SLGA)"),
+    PHW = list(id = "TERN/c37439a5", temporal = "Static",
+               resolution = "90 m",
+               description = "pH (water) (SLGA)"),
+    NTO = list(id = "TERN/e9484508", temporal = "Static",
+               resolution = "90 m",
+               description = "Total Nitrogen % (SLGA)"),
+    AVP = list(id = "TERN/c6ef289b", temporal = "Static",
+               resolution = "90 m",
+               description = "Available Phosphorus (mg/kg) (SLGA)"),
+    PTO = list(id = "TERN/be382e63", temporal = "Static",
+               resolution = "90 m",
+               description = "Total Phosphorus % (SLGA)"),
+    CEC = list(id = "TERN/5b4b2991", temporal = "Static",
+               resolution = "90 m",
+               description = "Cation Exchange Capacity (meq/100g) (SLGA)"),
+    ECE = list(id = "TERN/0d27cf8b", temporal = "Static",
+               resolution = "90 m",
+               description = "Effective Cation Exchange Capacity (meq/100g) (SLGA)"),
+    DUL = list(id = "TERN/de9ddc12", temporal = "Static",
+               resolution = "90 m",
+               description = "Drained upper limit water content % (SLGA)"),
+    L15 = list(id = "TERN/4443f5df", temporal = "Static",
+               resolution = "90 m",
+               description = "15 bar lower limit water content % (SLGA)"),
     SOILDIV   = list(id = "TERN/4a428d52", temporal = "Static",
                      resolution = "90 m",
-                     description = "Soil Beta Diversity (NMDS ordination)"),
+                     description = "Soil Beta Diversity (NMDS components)"),
     CANOPY    = list(id = "TERN/36c98155", temporal = "Static",
                      resolution = "30 m",
-                     description = "Canopy Height composite (OzTreeMap)"),
+                     description = "Canopy Height Best-pick composite (OzTreeMap)"),
     PHENOLOGY = list(id = "TERN/2bb0c81a", temporal = "Annual",
                      resolution = "500 m",
-                     description = "Land Surface Phenology (MODIS, 2003-2018)")
+                     description = "Land Surface Phenology")
   )
 
   layers_info <- vapply(datasets, function(ds) {
-    if (ds %in% c("AWC", "CLY", "SND", "SLT", "BDW", "PHC", "PHW", "NTO")) {
-      if (depth == "all") "6 depths" else paste0("Depth ", depth)
+    slga_datasets <- c(
+      "AWC", "CLY", "SND", "SLT", "BDW", "PHC", "PHW", "NTO", "AVP", "PTO",
+      "CEC", "ECE", "DUL", "L15"
+    )
+    if (ds %in% slga_datasets) {
+      if (depth == "all") {
+        "6 depths"
+      } else {
+        paste0("Depth ", depth)
+      }
     } else if (ds == "SMIPS") {
-      if (smips_collection == "all") "6 variants" else smips_collection
+      if (smips_collection == "all") {
+        "6 variants"
+      } else {
+        smips_collection
+      }
     } else {
       "Single"
     }
   }, character(1L))
 
   tbl <- data.table::data.table(
-    Alias       = datasets,
-    ID          = vapply(datasets, function(x) dataset_info[[x]]$id,
-                         character(1L)),
-    Layer       = layers_info,
-    Temporal    = vapply(datasets, function(x) dataset_info[[x]]$temporal,
-                         character(1L)),
-    Resolution  = vapply(datasets, function(x) dataset_info[[x]]$resolution,
-                         character(1L)),
+    Alias = datasets,
+    ID = vapply(datasets, function(x) dataset_info[[x]]$id, character(1L)),
+    Layer = layers_info,
+    Temporal = vapply(datasets, function(x) dataset_info[[x]]$temporal,
+                      character(1L)),
+    Resolution = vapply(datasets, function(x) dataset_info[[x]]$resolution,
+                        character(1L)),
     Description = vapply(datasets, function(x) dataset_info[[x]]$description,
                          character(1L))
   )

--- a/R/read_aet.R
+++ b/R/read_aet.R
@@ -1,4 +1,4 @@
-#' Read CMRSET Actual Evapotranspiration Data
+#' Read CMRSET Actual Evapotranspiration Data from TERN
 #'
 #' @description
 #' Wrapper around [read_tern()] for retrieving the CMRSET actual

--- a/R/read_aet.R
+++ b/R/read_aet.R
@@ -44,8 +44,8 @@
 #' # Quality assurance flags for June 2023
 #' r_qa <- read_aet("2023-06-01", collection = "pixel_qa")
 #'
-#' # ET from February 2000 (earliest available)
-#' r_early <- read_aet("2000-02-01")
+#' # ET from May 1987 (earliest available)
+#' r_early <- read_aet("1987-05-01")
 #'
 #' # Current/recent ET (within last month)
 #' r_recent <- read_aet(Sys.Date())

--- a/R/read_aet.R
+++ b/R/read_aet.R
@@ -1,8 +1,9 @@
 #' Read CMRSET Actual Evapotranspiration Data
 #'
 #' @description
-#' Wrapper around [read_tern()] for TERN/CMRSET evapotranspiration data.
-#' Provides monthly estimates of actual ET (mm/month) at 30 m resolution
+#' Wrapper around [read_tern()] for retrieving the CMRSET actual
+#' evapotranspiration data (v2.2) from the TERN Data Portal. This dataset
+#' provides monthly estimates of actual ET (mm/month) at 30 m resolution
 #' from February 2000 onwards.
 #'
 #' @param date A month to download (Date or character, e.g.

--- a/R/read_aet.R
+++ b/R/read_aet.R
@@ -4,30 +4,34 @@
 #' Wrapper around [read_tern()] for retrieving the CMRSET actual
 #' evapotranspiration data (v2.2) from the TERN Data Portal. This dataset
 #' provides monthly estimates of actual ET (mm/month) at 30 m resolution
-#' from February 2000 onwards. #FIXME: May 1987 actually.
+#' from May 1987 onwards, using the CSIRO MODIS Reflectance-based Scaling
+#' EvapoTranspiration (CMRSET) algorithm that combines potential
+#' evapotranspiration data from the Bureau of Meteorology together with
+#' satellite image data provided by MODIS, VIIRS, Landsat and Sentinel-2.
 #'
 #' @param date A month to download (Date or character, e.g.
 #'   \code{"2023-06-01"} or \code{as.Date("2023-06-01")}).  The value
 #'   is snapped to the first of the month internally.  Required.
 #' @param collection One of \code{"ETa"} (actual evapotranspiration in
-#'   mm/month, default) or \code{"pixel_qa"} (quality assurance flags).
+#'   mm/month, default) or \code{"pixel_qa"} (quality assurance attributes).
 #' @param api_key A \code{character} string containing your \acronym{TERN}
-#'   \acronym{API} key.  Defaults to automatic detection from your
+#'   \acronym{API} key. Defaults to automatic detection from your
 #'   \code{.Renviron} or \code{.Rprofile}.  See [get_key()] for setup.
 #' @param max_tries Maximum number of download retries before an error is
-#'   raised.  When \code{NULL} (default), resolved from
-#'   \code{getOption("nert.max_tries", 3L)}.  Pass an integer to override
-#'   for a single call.
+#'   raised. Default=\code{NULL}, in which case the maximum retry number is
+#'   resolved from the option \code{nert.max_tries} if that option exists.
+#'   (Defaults to 3 retries if \code{nert.max_tries} has not been set.)
 #' @param initial_delay Initial retry delay in seconds (doubles with each
-#'   attempt).  When \code{NULL} (default), resolved from
-#'   \code{getOption("nert.initial_delay", 1L)}.  Pass an integer to
-#'   override for a single call.
+#'   attempt). Default=\code{NULL}, in which case the initial delay is
+#'   resolved from the option \code{nert.initial_delay} if that option exists.
+#'   (Defaults to a 1 second initial delay if \code{nert.initial_delay} has
+#'   not been set.)
 #'
 #' @returns
-#' A [terra::rast()] object of the requested ET collection.
+#' A [terra::SpatRaster] object of the requested Evapotranspiration collection.
 #'
 #' @seealso
-#' [read_tern()], [read_smips()], [read_asc()]
+#' [read_tern()]
 #'
 #' @examplesIf interactive()
 #' # Actual evapotranspiration (ETa) for June 2023 (mm/month)
@@ -47,10 +51,13 @@
 #' r_recent <- read_aet(Sys.Date())
 #'
 #' @references
-#'   CMRSET portal:
-#'   <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/9fefa68b-dbed-4c20-88db-a9429fb4ba97>
+#'   McVicar, T., Vleeshouwer, J., Van Niel, T., Guerschman, J. &
+#'   Peña-Arancibia, J. (2022). Actual Evapotranspiration for Australia
+#'   using CMRSET algorithm. Version 1.0. Terrestrial Ecosystem Research
+#'   Network. (Dataset). \doi{10.25901/gg27-ck96}.
 #'
-#'   CMRSET DOI: \doi{10.25901/gg27-ck96}
+#'   TERM CMRSET Actual Evapotranspiration Point-of-truth metadata URL:
+#'   <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/9fefa68b-dbed-4c20-88db-a9429fb4ba97>
 #'
 #' @autoglobal
 #' @export
@@ -72,9 +79,7 @@ read_aet <- function(
 }
 
 
-# -- Internal AET handler ----------------------------------------------------
-
-#' Internal handler for AET/CMRSET (\code{TERN/9fefa68b})
+#' Internal handler for retrieving the AET data
 #'
 #' @param dots Named list of \code{...} args from [read_tern()].
 #' @param api_key URL-encoded API key.
@@ -83,7 +88,11 @@ read_aet <- function(
 #' @dev
 .read_tern_aet <- function(dots, api_key, max_tries, initial_delay) {
   # Accept both 'date' and the legacy 'month' parameter name
-  date <- if (!is.null(dots[["date"]])) dots[["date"]] else dots[["month"]]
+  date <- if (!is.null(dots[["date"]])) {
+    dots[["date"]]
+  } else {
+    dots[["month"]]
+  }
   if (is.null(date)) {
     cli::cli_abort(
       "AET requires a {.arg date} argument (monthly resolution),
@@ -106,13 +115,11 @@ read_aet <- function(
 }
 
 
-# -- AET date and URL helpers -----------------------------------------------
-
 #' Check User Input Months for AET Validity
 #'
 #' Validates and snaps a user-supplied date value to the first of the month,
 #' then checks it against the \acronym{AET} data availability window
-#' (from 2000-02-01 onwards).
+#' (from 1987-05-01 onwards).
 #'
 #' @param x User-entered date value (any format accepted by [.check_date()]).
 #' @returns A \code{POSIXct} object snapped to the first of the requested
@@ -122,11 +129,9 @@ read_aet <- function(
 .check_aet_date <- function(x) {
   x <- .check_date(x)
   x <- lubridate::floor_date(x, "month")
-  yr <- lubridate::year(x)
-  mo <- lubridate::month(x)
-  if (yr < 2000L || (yr == 2000L && mo < 2L)) {
+  if (x < as.POSIXct("1987-05-01")) {
     cli::cli_abort(
-      "AET data are not available before 2000-02-01.
+      "AET data are not available before 1987-05-01.
        You requested {format(x, '%Y-%m-%d')}."
     )
   }
@@ -134,7 +139,7 @@ read_aet <- function(
 }
 
 
-#' Build a GDAL vsicurl URL for an AET Collection
+#' Build a GDAL vsicurl URL to retrieve AET data
 #'
 #' @param .collection The user-supplied \acronym{AET} collection
 #'   (\code{"ETa"} or \code{"pixel_qa"}).

--- a/R/read_aet.R
+++ b/R/read_aet.R
@@ -4,7 +4,7 @@
 #' Wrapper around [read_tern()] for retrieving the CMRSET actual
 #' evapotranspiration data (v2.2) from the TERN Data Portal. This dataset
 #' provides monthly estimates of actual ET (mm/month) at 30 m resolution
-#' from February 2000 onwards.
+#' from February 2000 onwards. #FIXME: May 1987 actually.
 #'
 #' @param date A month to download (Date or character, e.g.
 #'   \code{"2023-06-01"} or \code{as.Date("2023-06-01")}).  The value

--- a/R/read_asc.R
+++ b/R/read_asc.R
@@ -1,96 +1,83 @@
 #' Read Australian Soil Classification (ASC) Data from TERN
 #'
 #' @description
-#' Wrapper around [read_tern()] for Australian Soil Classification (\acronym{ASC})
-#' soil order classes at 90 m resolution. Returns character soil order descriptions
-#' (e.g., "2 - Sodosol") with optional mapping reliability (confusion index).
+#' Wrapper around [read_tern()] for retrieving Australian Soil Classification
+#' (\acronym{ASC}) soil order classes from the TERN Data Portal. The ASC dataset
+#' provides a comprehensive map at 90m X 90m spatial resolution across
+#' Australia, mapping each spatial pixel to one of 14 soil order classes using
+#' a Random Forest classifier. The dataset also provides a confusion index
+#' raster that estimates the uncertainty (between 0.0 and 1.0) associated with
+#' the classification.
 #'
-#' @details
-#' The ASC dataset provides soil order classifications based on the Australian
-#' Soil Classification system. Each pixel contains the predicted soil order and
-#' associated reliability/uncertainty estimates.
-#'
-#' **Output data type:** Character (soil order names and codes)
-#'
-#' **Reliability:** Confusion Index indicates mapping uncertainty (lower = more reliable)
-#'
-#' @param confusion_index A `logical` value. If `FALSE` (default), returns
-#'   estimated \acronym{ASC} soil order classes (character). If `TRUE`, returns
-#'   the Confusion Index (numeric, 0-100) indicating mapping reliability.
-#' @param api_key A `character` string containing your \acronym{API} key,
-#'   a random string provided to you by \acronym{TERN}, for the request.
-#'   Defaults to automatically detecting your key from your local .Renviron,
-#'   .Rprofile or similar.  Alternatively, you may directly provide your key as
-#'   a string here or use functionality like that from \CRANpkg{keyring}.  If
-#'   nothing is provided, you will be prompted on how to set up your \R session
-#'   so that it is auto-detected and a browser window will open at the
-#'   \acronym{TERN} website for you to request a key.
+#' @param collection The ASC dataset collection variant (default \code{"EV"}). Options:
+#'   \describe{
+#'     \item{\code{"EV"}}{**(Estimated) Soil Order Class** (character). The
+#'       estimated ASC soil order class. Each pixel of the raster maps to one
+#'       of 14 soil order classes: Vertosol, Sodosol, Dermosol, Chromosol,
+#'       Ferrosol, Kurosol, Tenosol, Kandosol, Hydrosol, Podosol, Rudosol,
+#'       Calcarasol, Organosol, Anthroposol.}
+#'     \item{\code{"CI"}}{**Confusion Index** (0-1). A unitless index between
+#'       0.0 and 1.0, approximating the uncertainty of the Random Forest
+#'       classification for the soil order at each pixel. (A higher value of the
+#'       confusion index means that the classification at that pixel is more
+#'       uncertain.)}
+#'   }
+#' @param api_key A \code{character} string containing your \acronym{TERN}
+#'   \acronym{API} key. Defaults to automatic detection from your
+#'   \code{.Renviron} or \code{.Rprofile}.  See [get_key()] for setup.
 #' @param max_tries Maximum number of download retries before an error is
-#'   raised.  When `NULL` (default), resolved from
-#'   `getOption("nert.max_tries", 3L)`.  Pass an integer to override for
-#'   a single call.
+#'   raised. Default=\code{NULL}, in which case the maximum retry number is
+#'   resolved from the option \code{nert.max_tries} if that option exists.
+#'   (Defaults to 3 retries if \code{nert.max_tries} has not been set.)
 #' @param initial_delay Initial retry delay in seconds (doubles with each
-#'   attempt).  When `NULL` (default), resolved from
-#'   `getOption("nert.initial_delay", 1L)`.  Pass an integer to override
-#'   for a single call.
+#'   attempt). Default=\code{NULL}, in which case the initial delay is
+#'   resolved from the option \code{nert.initial_delay} if that option exists.
+#'   (Defaults to a 1 second initial delay if \code{nert.initial_delay} has
+#'   not been set.)
 #'
-#' @family COGs
+#' @returns
+#' A [terra::SpatRaster] object containing the soil order classes (or the
+#' values of the confusion index).
+#'
+#' @seealso
+#' [read_tern()]
 #'
 #' @examplesIf interactive()
-#'
 #' # Australian Soil Classification (soil orders as character)
 #' r_asc <- read_asc()
 #' autoplot(r_asc)
 #'
-#' # Confusion Index (mapping reliability, lower = more reliable)
-#' r_ci <- read_asc(confusion_index = TRUE)
+#' # Confusion Index (uncertainty of the classification, higher=more uncertain)
+#' r_ci <- read_asc(collection = "CI")
 #' autoplot(r_ci)
 #'
-#' @returns A  [terra::rast()] object.
-#' @source
-#'   ASC mosaic metadata (estimated soil-order class and confusion index):
-#'   <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/15728dba-b49c-4da5-9073-13d8abe67d7c>.
-#'   The underlying COG endpoints (\code{ASC_EV_C_P_AU_TRN_N.cog.tif} and
-#'   \code{ASC_CI_C_P_AU_TRN_N.cog.tif} under
-#'   \code{/model-derived/slga/NationalMaps/SoilClassifications/ASC/90m/} on
-#'   \code{data.tern.org.au}) require an authenticated request and are
-#'   constructed internally by this package.
+#' @references
+#'   Searle, R. (2021). Australian Soil Classification Map. Version 1.
+#'   Terrestrial Ecosystem Research Network. (Dataset).
+#'   \doi{10.25901/edyr-wg85}.
+#'
+#'   TERN ASC Point-of-truth metadata URL:
+#'   <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/15728dba-b49c-4da5-9073-13d8abe67d7c>
+#'
 #' @autoglobal
-#' @references <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/15728dba-b49c-4da5-9073-13d8abe67d7c>
 #' @export
 read_asc <- function(
-  confusion_index = FALSE,
+  collection = "EV",
   api_key = get_key(),
   max_tries = NULL,
   initial_delay = NULL
 ) {
-  if (!is.logical(confusion_index) ||
-      length(confusion_index) != 1L ||
-      is.na(confusion_index)) {
-    cli::cli_abort(
-      "{.arg confusion_index} must be a single non-NA logical value \\
-       ({.code TRUE} or {.code FALSE})."
-    )
-  }
-  api_key <- .check_api_key(api_key)
-  dl_file <- data.table::fifelse(
-    confusion_index,
-    "ASC_CI_C_P_AU_TRN_N.cog.tif",
-    "ASC_EV_C_P_AU_TRN_N.cog.tif"
+  read_tern(
+    "ASC",
+    collection = collection,
+    api_key = api_key,
+    max_tries = max_tries,
+    initial_delay = initial_delay
   )
-
-  full_url <- sprintf(
-    "/vsicurl/https://apikey:%s@data.tern.org.au/model-derived/slga/NationalMaps/SoilClassifications/ASC/90m/%s",
-    api_key,
-    dl_file
-  )
-  return(.read_cog(full_url, max_tries, initial_delay))
 }
 
 
-# -- Internal ASC handler ----------------------------------------------------
-
-#' Internal handler for ASC (\code{TERN/15728dba})
+#' Internal handler for retrieving ASC rasters
 #'
 #' @param dots Named list of \code{...} args from [read_tern()].
 #' @param api_key URL-encoded API key.
@@ -107,11 +94,7 @@ read_asc <- function(
   approved <- c("EV", "CI")
   collection <- rlang::arg_match(collection, approved)
 
-  dl_file <- data.table::fifelse(
-    collection == "EV",
-    "ASC_EV_C_P_AU_TRN_N.cog.tif",
-    "ASC_CI_C_P_AU_TRN_N.cog.tif"
-  )
+  dl_file <- paste0("ASC_", collection, "_C_P_AU_TRN_N.cog.tif")
   full_url <- sprintf(
     "/vsicurl/https://apikey:%s@data.tern.org.au/model-derived/slga/NationalMaps/SoilClassifications/ASC/90m/%s",
     api_key,

--- a/R/read_asc.R
+++ b/R/read_asc.R
@@ -1,4 +1,4 @@
-#' Read Australian Soil Classification (ASC) Data
+#' Read Australian Soil Classification (ASC) Data from TERN
 #'
 #' @description
 #' Wrapper around [read_tern()] for Australian Soil Classification (\acronym{ASC})

--- a/R/read_canopy_height.R
+++ b/R/read_canopy_height.R
@@ -1,4 +1,4 @@
-#' Read Canopy Height from TERN
+#' Read OzTreeMap Canopy Height Data from TERN
 #'
 #' Read the OzTreeMap Canopy Height composite Cloud Optimised GeoTIFF
 #' (\acronym{COG}) from \acronym{TERN}.  This product provides a nationwide

--- a/R/read_canopy_height.R
+++ b/R/read_canopy_height.R
@@ -1,58 +1,63 @@
 #' Read OzTreeMap Canopy Height Data from TERN
 #'
-#' Read the OzTreeMap Canopy Height composite Cloud Optimised GeoTIFF
-#' (\acronym{COG}) from \acronym{TERN}.  This product provides a nationwide
-#' canopy height map at 30 m resolution derived from Landsat imagery.
-#'
-#' This is a single static product --- no date or collection arguments are
-#' required.
-#'
-#' This is a convenience wrapper around
-#' \code{read_tern("CANOPY")}; see [read_tern()] for full details and
-#' additional datasets.
+#' @description
+#' Wrapper around [read_tern()] for retrieving the OzTreeMap Best-Pick
+#' Canopy Height model dataset from the TERN Data Portal. The model estimates
+#' the vegetation canopy height (in metres) at 30m X 30m spatial resolution
+#' across Australia, based on underlying ML-derived vegetation models
+#' tuned to variable time periods between 2007 and 2020.
 #'
 #' @param api_key A \code{character} string containing your \acronym{TERN}
-#'   \acronym{API} key.  Defaults to automatic detection via [get_key()].
+#'   \acronym{API} key. Defaults to automatic detection from your
+#'   \code{.Renviron} or \code{.Rprofile}.  See [get_key()] for setup.
 #' @param max_tries Maximum number of download retries before an error is
-#'   raised.  When \code{NULL} (default), resolved from
-#'   \code{getOption("nert.max_tries", 3L)}.  Pass an integer to override
-#'   for a single call.
+#'   raised. Default=\code{NULL}, in which case the maximum retry number is
+#'   resolved from the option \code{nert.max_tries} if that option exists.
+#'   (Defaults to 3 retries if \code{nert.max_tries} has not been set.)
 #' @param initial_delay Initial retry delay in seconds (doubles with each
-#'   attempt).  When \code{NULL} (default), resolved from
-#'   \code{getOption("nert.initial_delay", 1L)}.  Pass an integer to
-#'   override for a single call.
+#'   attempt). Default=\code{NULL}, in which case the initial delay is
+#'   resolved from the option \code{nert.initial_delay} if that option exists.
+#'   (Defaults to a 1 second initial delay if \code{nert.initial_delay} has
+#'   not been set.)
 #'
-#' @family COGs
+#' @returns
+#' A [terra::SpatRaster] object of the requested vegetation canopy height.
+#' Note that the raster returned by this function uses the Australian Albers
+#' (EPSG:3577) coordinate reference system, not WGS84 (EPSG:4326).
+#'
+#' @seealso
+#' [read_tern()]
 #'
 #' @examplesIf interactive()
 #' r <- read_canopy_height()
 #' autoplot(r)
 #'
-#' @returns A [terra::rast()] object of the national OzTreeMap canopy height
-#'   composite.
-#'
 #' @references
-#'   <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/36c98155-c137-44b8-b4e0-6a3e824bbfba>
+#'   Pucino, N., McVicar, T., Levick, S. & Albert van Dijk (2025).
+#'   Australia-Wide 30 m Machine Learning-Derived Canopy Height Models
+#'   Composites: Best Pick and Median. Version 1. Terrestrial Ecosystem
+#'   Research Network. (Dataset). \doi{10.25901/xqv7-jk46}.
+#'
+#'   TERN Canopy Height model Point-of-truth metadata URL:
+#'   <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/36c98155-39c8-4eec-9070-a978933f3fa3>
 #'
 #' @autoglobal
 #' @export
 read_canopy_height <- function(
-  api_key       = get_key(),
-  max_tries     = NULL,
+  api_key = get_key(),
+  max_tries = NULL,
   initial_delay = NULL
 ) {
   read_tern(
     "CANOPY",
-    api_key       = api_key,
-    max_tries     = max_tries,
+    api_key = api_key,
+    max_tries = max_tries,
     initial_delay = initial_delay
   )
 }
 
 
-# -- Internal Canopy Height handler -----------------------------------------
-
-#' Internal handler for Canopy Height (\code{TERN/36c98155})
+#' Internal handler for retrieving Canopy Height data
 #'
 #' @param api_key URL-encoded API key.
 #' @param max_tries,initial_delay Passed to [.read_cog()].

--- a/R/read_phenology.R
+++ b/R/read_phenology.R
@@ -8,7 +8,7 @@
 #' imagery.
 #'
 #' @section Phenology metrics:
-#' Eight phenological metrics are available via the \code{collection}
+#' Eleven phenological metrics are available via the \code{collection}
 #' argument:
 #' \describe{
 #'   \item{\code{"SGS"}}{**Start of Growing Season** (default). A number
@@ -35,13 +35,26 @@
 #'   \item{\code{"EVII"}}{**Integral of the EVI across the season**. The
 #'     calculated integral of the Enhanced Vegetation Index (including the
 #'     factor of 10000 scaling) under the growing season cycle curve.}
+#'   \item{\code{"SGS_month"}}{**Start of the growing season by month**.
+#'     A number between 1 and 12, indicating the month for the start of the
+#'     growing season (i.e., the \code{"SGS"} metric but reprocessed to
+#'     monthly time resolution).}
+#'   \item{\code{"PGS_month"}}{**Peak of the growing season by month**.
+#'     A number between 1 and 12, indicating the month for the peak of the
+#'     growing season (i.e., the \code{"PGS"} metric but reprocessed to
+#'     monthly time resolution).}
+#'   \item{\code{"EGS_month"}}{**End of the growing season by month**.
+#'     A number between 1 and 12, indicating the month for the end of the
+#'     growing season (i.e., the \code{"EGS"} metric but reprocessed to
+#'     monthly time resolution).}
 #' }
 #'
 #' @param year An integer year (2003--2018).
 #' @param season Season number: \code{1} (default) or \code{2}.
 #' @param collection Phenology metric abbreviation.  One of \code{"SGS"}
 #'   (default), \code{"PGS"}, \code{"EGS"}, \code{"LGS"}, \code{"EVI1"},
-#'   \code{"EVI2"}, \code{"EVIP"}, or \code{"EVII"}.
+#'   \code{"EVI2"}, \code{"EVIP"}, \code{"EVII"}, \code{"SGS_month"},
+#'   \code{"PGS_month"} or \code{"EGS_month"}.
 #' @param api_key A \code{character} string containing your \acronym{TERN}
 #'   \acronym{API} key. Defaults to automatic detection from your
 #'   \code{.Renviron} or \code{.Rprofile}.  See [get_key()] for setup.
@@ -116,7 +129,10 @@ read_phenology <- function(
   EVI1 = "5_Minimum_EVI_value_before_PGS",
   EVI2 = "6_Minimum_EVI_value_after_PGS",
   EVIP = "7_Peak_EVI_value_of_the_growing_season",
-  EVII = "8_Integral_EVI_value_of_the_growing_season"
+  EVII = "8_Integral_EVI_value_of_the_growing_season",
+  SGS_month = "9_Start_of_the_growing_season_by_month",
+  PGS_month = "10_Peak_of_the_growing_season_by_month",
+  EGS_month = "11_End_of_the_growing_season_by_month"
 )
 
 
@@ -148,7 +164,15 @@ read_phenology <- function(
   }
 
   metric_dir <- .phenology_metrics[[collection]]
-  fname <- sprintf("%s_%d_Season%d.tif", collection, year, season)
+
+  # For the monthly rasters, strip the "_month" bit off the end
+  # to match to the raster filenames in the TERN server directory
+  fname <- sprintf(
+    "%s_%d_Season%d.tif",
+    sub("_month", "", collection, fixed = TRUE),
+    year,
+    season
+  )
   full_url <- sprintf(
     "/vsicurl/https://apikey:%s@data.tern.org.au/remote-sensing/modis/phenology_myd13a1/%s/%s",
     api_key, metric_dir, fname

--- a/R/read_phenology.R
+++ b/R/read_phenology.R
@@ -76,7 +76,7 @@
 #'   (Dataset). URL: <https://portal.tern.org.au/metadata/2bb0c81a-41a9-434c-b87a-db0301cb52fb>.
 #'
 #'   TERN Land Surface Phenology Point-of-truth metadata URL:
-#'   <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/2bb0c81a-5a09-4a0e-bd86-5cd2be8def26>
+#'   <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/2bb0c81a-41a9-434c-b87a-db0301cb52fb>
 #'
 #' @autoglobal
 #' @export

--- a/R/read_phenology.R
+++ b/R/read_phenology.R
@@ -1,49 +1,65 @@
 #' Read Land Surface Phenology from TERN
 #'
-#' Read Australian Land Surface Phenology Cloud Optimised GeoTIFF
-#' (\acronym{COG}) files from \acronym{TERN}.  This product provides
-#' phenological metrics derived from MODIS MYD13A1 imagery at 500 m
-#' resolution.  Data are available for years 2003--2018, with up to two
-#' growing seasons per year.
+#' Wrapper around [read_tern()] for retrieving the Australian land surface
+#' phenology dataset (v1.0) from the TERN Data Portal. This data comprises
+#' phenology metrics from two growing seasons per year between 2003 and
+#' 2018 (inclusive), estimated at 500m X 500m spatial resolution across
+#' all of Australia using thresholded MODIS Enhanced Vegetation Index (EVI)
+#' imagery.
 #'
 #' @section Phenology metrics:
-#' Ten phenological metrics are available (use as the \code{collection}
-#' argument):
+#' Eight phenological metrics are available via the \code{collection}
+#' argument:
 #' \describe{
-#'   \item{\code{"SGS"}}{Start of Growing Season (default).}
-#'   \item{\code{"PGS"}}{Peak of Growing Season.}
-#'   \item{\code{"EGS"}}{End of Growing Season.}
-#'   \item{\code{"LGS"}}{Length of Growing Season.}
-#'   \item{\code{"SOS"}}{Start of Season.}
-#'   \item{\code{"POS"}}{Peak of Season.}
-#'   \item{\code{"EOS"}}{End of Season.}
-#'   \item{\code{"LOS"}}{Length of Season.}
-#'   \item{\code{"ROG"}}{Rate of Greening.}
-#'   \item{\code{"ROS"}}{Rate of Senescence.}
+#'   \item{\code{"SGS"}}{**Start of Growing Season** (default). A number
+#'     between -150 and 345 indicating the start of the growing season (with
+#'     negative numbers meaning the prior year).}
+#'   \item{\code{"PGS"}}{**Peak of Growing Season**. A number between 9 and
+#'     361 indicating the day of the year for the peak of the growing season.}
+#'   \item{\code{"EGS"}}{**End of Growing Season**. A number between 25 and
+#'     519 indicating the day of the year that marks the end of the growing
+#'     season, with numbers above 365 (or 366 for leap years) meaning the
+#'     following year.}
+#'   \item{\code{"LGS"}}{**Length of Growing Season**, measured in days.}
+#'   \item{\code{"EVI1"}}{**Minimum of EVI before peak**. A unitless index
+#'     between 0 and 10000 (i.e., scaled by 10000) for the minimum
+#'     value of the Enhanced Vegetation Index *before* the peak of the growing
+#'     season.}
+#'   \item{\code{"EVI2"}}{**Minimum of EVI after peak**. A unitless index
+#'     between 0 and 10000 (i.e., scaled by 10000) for the minimum
+#'     value of the Enhanced Vegetation Index *after* the peak of the growing
+#'     season.}
+#'   \item{\code{"EVIP"}}{**Peak EVI**. A unitless index between 0 and 10000
+#'     (i.e., scaled by 10000) for the value of the Enhanced Vegetation Index
+#'     *at* the peak of the growing season.}
+#'   \item{\code{"EVII"}}{**Integral of the EVI across the season**. The
+#'     calculated integral of the Enhanced Vegetation Index (including the
+#'     factor of 10000 scaling) under the growing season cycle curve.}
 #' }
-#'
-#' This is a convenience wrapper around
-#' \code{read_tern("PHENOLOGY", ...)}; see [read_tern()] for full
-#' details and additional datasets.
 #'
 #' @param year An integer year (2003--2018).
 #' @param season Season number: \code{1} (default) or \code{2}.
 #' @param collection Phenology metric abbreviation.  One of \code{"SGS"}
-#'   (default), \code{"PGS"}, \code{"EGS"}, \code{"LGS"}, \code{"SOS"},
-#'   \code{"POS"}, \code{"EOS"}, \code{"LOS"}, \code{"ROG"}, or
-#'   \code{"ROS"}.
+#'   (default), \code{"PGS"}, \code{"EGS"}, \code{"LGS"}, \code{"EVI1"},
+#'   \code{"EVI2"}, \code{"EVIP"}, or \code{"EVII"}.
 #' @param api_key A \code{character} string containing your \acronym{TERN}
-#'   \acronym{API} key.  Defaults to automatic detection via [get_key()].
+#'   \acronym{API} key. Defaults to automatic detection from your
+#'   \code{.Renviron} or \code{.Rprofile}.  See [get_key()] for setup.
 #' @param max_tries Maximum number of download retries before an error is
-#'   raised.  When \code{NULL} (default), resolved from
-#'   \code{getOption("nert.max_tries", 3L)}.  Pass an integer to override
-#'   for a single call.
+#'   raised. Default=\code{NULL}, in which case the maximum retry number is
+#'   resolved from the option \code{nert.max_tries} if that option exists.
+#'   (Defaults to 3 retries if \code{nert.max_tries} has not been set.)
 #' @param initial_delay Initial retry delay in seconds (doubles with each
-#'   attempt).  When \code{NULL} (default), resolved from
-#'   \code{getOption("nert.initial_delay", 1L)}.  Pass an integer to
-#'   override for a single call.
+#'   attempt). Default=\code{NULL}, in which case the initial delay is
+#'   resolved from the option \code{nert.initial_delay} if that option exists.
+#'   (Defaults to a 1 second initial delay if \code{nert.initial_delay} has
+#'   not been set.)
 #'
-#' @family COGs
+#' @returns
+#' A [terra::SpatRaster] object of the requested phenology metric.
+#'
+#' @seealso
+#' [read_tern()]
 #'
 #' @examplesIf interactive()
 #' # Read Start of Growing Season for 2018, Season 1
@@ -54,38 +70,35 @@
 #' r_egs <- read_phenology(year = 2015, season = 2, collection = "EGS")
 #' autoplot(r_egs)
 #'
-#' # Rate of Greening
-#' r_rog <- read_phenology(year = 2010, collection = "ROG")
-#'
-#' @returns A [terra::rast()] object of the national phenology mosaic for
-#'   the requested year, season, and metric.
-#'
 #' @references
+#'   Xie, Q. & Huete, A. (2024). Australian land surface phenology dataset at
+#'   500m resolution. Version 1.0. Terrestrial Ecosystem Research Network.
+#'   (Dataset). URL: <https://portal.tern.org.au/metadata/2bb0c81a-41a9-434c-b87a-db0301cb52fb>.
+#'
+#'   TERN Land Surface Phenology Point-of-truth metadata URL:
 #'   <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/2bb0c81a-5a09-4a0e-bd86-5cd2be8def26>
 #'
 #' @autoglobal
 #' @export
 read_phenology <- function(
-  year          = NULL,
-  season        = 1L,
-  collection    = "SGS",
-  api_key       = get_key(),
-  max_tries     = NULL,
+  year = NULL,
+  season = 1L,
+  collection = "SGS",
+  api_key = get_key(),
+  max_tries = NULL,
   initial_delay = NULL
 ) {
   read_tern(
     "PHENOLOGY",
-    year          = year,
-    season        = season,
-    collection    = collection,
-    api_key       = api_key,
-    max_tries     = max_tries,
+    year = year,
+    season = season,
+    collection = collection,
+    api_key = api_key,
+    max_tries = max_tries,
     initial_delay = initial_delay
   )
 }
 
-
-# -- Phenology metric registry ----------------------------------------------
 
 #' Phenology metric registry
 #'
@@ -100,16 +113,12 @@ read_phenology <- function(
   PGS = "2_Peak_of_the_growing_season",
   EGS = "3_End_of_the_growing_season",
   LGS = "4_Length_of_the_growing_season",
-  SOS = "5_Start_of_season",
-  POS = "6_Peak_of_season",
-  EOS = "7_End_of_season",
-  LOS = "8_Length_of_season",
-  ROG = "9_Rate_of_greening",
-  ROS = "10_Rate_of_senescence"
+  EVI1 = "5_Minimum_EVI_value_before_PGS",
+  EVI2 = "6_Minimum_EVI_value_after_PGS",
+  EVIP = "7_Peak_EVI_value_of_the_growing_season",
+  EVII = "8_Integral_EVI_value_of_the_growing_season"
 )
 
-
-# -- Internal Phenology handler ---------------------------------------------
 
 #' Internal handler for Land Surface Phenology (\code{TERN/2bb0c81a})
 #'
@@ -119,9 +128,17 @@ read_phenology <- function(
 #' @autoglobal
 #' @dev
 .read_tern_phenology <- function(dots, api_key, max_tries, initial_delay) {
-  year       <- as.integer(dots[["year"]])
-  season     <- if (!is.null(dots[["season"]])) as.integer(dots[["season"]]) else 1L
-  collection <- if (!is.null(dots[["collection"]])) dots[["collection"]] else "SGS"
+  year <- as.integer(dots[["year"]])
+  season <- if (!is.null(dots[["season"]])) {
+    as.integer(dots[["season"]])
+  } else {
+    1L
+  }
+  collection <- if (!is.null(dots[["collection"]])) {
+    dots[["collection"]]
+  } else {
+    "SGS"
+  }
 
   approved_metrics <- names(.phenology_metrics)
   collection <- rlang::arg_match(collection, approved_metrics)

--- a/R/read_slga.R
+++ b/R/read_slga.R
@@ -1,37 +1,23 @@
 #' Read SLGA Soil Attributes from TERN
 #'
-#' Read Soil and Landscape Grid of Australia (\acronym{SLGA}) Cloud Optimised
-#' GeoTIFF (\acronym{COG}) files from \acronym{TERN}.  Eight soil attributes
-#' are available as static 90 m national products, each with six standard
-#' depth layers and two statistics (estimated value or confidence interval).
+#' Wrapper around [read_tern()] for retrieving various Soil and Landscape
+#' Grid of Australia (SLGA) datasets from the TERN Data Portal. Eight soil
+#' attributes are available at 90m X 90m spatial resolution across Australia,
+#' each with six standard depth layers (0-5cm, 5-15cm, 15-30cm, 30-60cm,
+#' 60-100cm, 100-200cm) and two statistics (estimated value, confidence
+#' interval).
 #'
-#' @section Supported attributes:
+#' @section Supported soil attributes:
 #' \describe{
-#'   \item{\code{"AWC"}}{Available Water Capacity (mm)}
-#'   \item{\code{"CLY"}}{Clay content (percent)}
-#'   \item{\code{"SND"}}{Sand content (percent)}
-#'   \item{\code{"SLT"}}{Silt content (percent)}
-#'   \item{\code{"BDW"}}{Bulk Density whole earth (g/cm3)}
-#'   \item{\code{"PHC"}}{pH (CaCl2)}
-#'   \item{\code{"PHW"}}{pH (water)}
-#'   \item{\code{"NTO"}}{Total Nitrogen (percent)}
+#'   \item{\code{"AWC"}}{Available Water Capacity (%)}
+#'   \item{\code{"CLY"}}{Clay content (%)}
+#'   \item{\code{"SND"}}{Sand content (%)}
+#'   \item{\code{"SLT"}}{Silt content (%)}
+#'   \item{\code{"BDW"}}{Bulk Density (Whole Earth) (g/cm3)}
+#'   \item{\code{"PHC"}}{pH (of 1:5 soil/0.01M CaCl2 extract)}
+#'   \item{\code{"PHW"}}{pH (of 1:5 soil water solution)}
+#'   \item{\code{"NTO"}}{Total Nitrogen (%)}
 #' }
-#'
-#' @section Depth layers:
-#' Six standard \acronym{GlobalSoilMap} depth intervals are available
-#' (values in cm):
-#' \tabular{l}{
-#'   \code{"000_005"} — 0--5 cm (default) \cr
-#'   \code{"005_015"} — 5--15 cm \cr
-#'   \code{"015_030"} — 15--30 cm \cr
-#'   \code{"030_060"} — 30--60 cm \cr
-#'   \code{"060_100"} — 60--100 cm \cr
-#'   \code{"100_200"} — 100--200 cm \cr
-#' }
-#'
-#' This is a convenience wrapper around
-#' \code{read_tern(<attribute>, ...)}; see [read_tern()] for full
-#' details and additional datasets.
 #'
 #' @param attribute One of \code{"AWC"}, \code{"CLY"}, \code{"SND"},
 #'   \code{"SLT"}, \code{"BDW"}, \code{"PHC"}, \code{"PHW"}, or
@@ -42,17 +28,23 @@
 #' @param collection One of \code{"EV"} (estimated value, default) or
 #'   \code{"CI"} (confidence interval).
 #' @param api_key A \code{character} string containing your \acronym{TERN}
-#'   \acronym{API} key.  Defaults to automatic detection via [get_key()].
+#'   \acronym{API} key. Defaults to automatic detection from your
+#'   \code{.Renviron} or \code{.Rprofile}.  See [get_key()] for setup.
 #' @param max_tries Maximum number of download retries before an error is
-#'   raised.  When \code{NULL} (default), resolved from
-#'   \code{getOption("nert.max_tries", 3L)}.  Pass an integer to override
-#'   for a single call.
+#'   raised. Default=\code{NULL}, in which case the maximum retry number is
+#'   resolved from the option \code{nert.max_tries} if that option exists.
+#'   (Defaults to 3 retries if \code{nert.max_tries} has not been set.)
 #' @param initial_delay Initial retry delay in seconds (doubles with each
-#'   attempt).  When \code{NULL} (default), resolved from
-#'   \code{getOption("nert.initial_delay", 1L)}.  Pass an integer to
-#'   override for a single call.
+#'   attempt). Default=\code{NULL}, in which case the initial delay is
+#'   resolved from the option \code{nert.initial_delay} if that option exists.
+#'   (Defaults to a 1 second initial delay if \code{nert.initial_delay} has
+#'   not been set.)
 #'
-#' @family COGs
+#' @returns
+#' A [terra::SpatRaster] object of the requested SLGA soil attribute.
+#'
+#' @seealso
+#' [read_tern()]
 #'
 #' @examplesIf interactive()
 #' # Read clay content at 0-5 cm depth
@@ -65,22 +57,75 @@
 #' # Read pH (CaCl2) confidence interval at 30-60 cm
 #' r_phc <- read_slga("PHC", depth = "030_060", collection = "CI")
 #'
-#' @returns A [terra::rast()] object of the national SLGA mosaic for the
-#'   requested attribute, depth, and statistic.
-#'
 #' @references
-#'   AWC: <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/482301c2-2837-4b0b-bf95-4883a04e5ff7>
-#'
-#'   SLGA: <https://esoil.io/TERNLandscapes/Public/Pages/SLGA/>
+#' \describe{
+#'   \item{**AWC: Available Volumetric Water Capacity**}{
+#'     Searle, R., Nimalka Somarathna, P. & Malone, B. (2023). Soil and
+#'     Landscape Grid National Soil Attribute Maps - Available Volumetric
+#'     Water Capacity (Percent) (3 arc second resolution) Version 2.
+#'     Version 2.0. Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/4jwj-na34}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/482301c2-b9a1-4345-b142-815f9b37890a>
+#'   }
+#'   \item{**CLY: Clay content**}{
+#'     Malone, B. & Searle, R. (2022). Soil and Landscape Grid National
+#'     Soil Attribute Maps - Clay (3" resolution) - Release 2. Version 2.
+#'     Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/hc4s-3130}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/f95dc442-013b-4fad-b31f-91ba86fbe7f5>
+#'   }
+#'   \item{**SND: Sand content**}{
+#'     Malone, B. & Searle, R. (2022). Soil and Landscape Grid National Soil
+#'     Attribute Maps - Sand (3" resolution) - Release 2. Version 2.0.
+#'     Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/rjmy-pa10}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/4224ddff-5fb4-4170-b5ea-c0c500599700>
+#'   }
+#'   \item{**SLT: Silt content**}{
+#'     Malone, B. & Searle, R. (2022). Soil and Landscape Grid National Soil
+#'     Attribute Maps - Silt (3" resolution) - Release 2. Version 2.0.
+#'     Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/2ew1-0w57}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/11375f04-b5cd-46a7-bcac-0e83fcb58605>
+#'   }
+#'   \item{**BDW: Bulk Density (Whole Earth)**}{
+#'     Malone, B. (2023). Soil and Landscape Grid National Soil Attribute
+#'     Maps - Bulk Density - Whole Earth - Release 2. Version 2.
+#'     Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/gxyn-pd07}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/95978aec-6ba8-446b-a721-2b875d9f61a8>
+#'   }
+#'   \item{**PHC: pH (of 1:5 soil/0.01M CaCl2 extract)**}{
+#'     Malone, B. & Searle, R. (2024). Soil and Landscape Grid National Soil
+#'     Attribute Maps - pH - Calcium Chloride (3" resolution) - Release 2.
+#'     Version 2. Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/7320-hw30}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/258afc98-7407-4781-b241-cb0293b4b8aa>
+#'   }
+#'   \item{**PHW: pH (of 1:5 soil water solution)**}{
+#'     Malone, B. (2022). Soil and Landscape Grid National Soil Attribute
+#'     Maps - pH (Water) (3" resolution) - Release 1. Version 1.0.
+#'     Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/37z2-0q10}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/c37439a5-e622-44ab-9c24-bfd632d8203c>
+#'   }
+#'   \item{**NTO: Total nitrogen**}{
+#'     Malone, B. & Searle, R. (2024). Soil and Landscape Grid National Soil
+#'     Attribute Maps - Total Nitrogen (3" resolution) - Release 2. Version 2.
+#'     Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/pm2n-ww12}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/e9484508-c705-4c23-9195-f26d64b9d4f1>
+#'   }
+#' }
 #'
 #' @autoglobal
 #' @export
 read_slga <- function(
   attribute,
-  depth         = "000_005",
-  collection    = "EV",
-  api_key       = get_key(),
-  max_tries     = NULL,
+  depth = "000_005",
+  collection = "EV",
+  api_key = get_key(),
+  max_tries = NULL,
   initial_delay = NULL
 ) {
   approved_attrs <- c("AWC", "CLY", "SND", "SLT", "BDW", "PHC", "PHW", "NTO")
@@ -88,16 +133,14 @@ read_slga <- function(
   attribute <- rlang::arg_match(attribute, approved_attrs)
   read_tern(
     attribute,
-    depth         = depth,
-    collection    = collection,
-    api_key       = api_key,
-    max_tries     = max_tries,
+    depth = depth,
+    collection = collection,
+    api_key = api_key,
+    max_tries = max_tries,
     initial_delay = initial_delay
   )
 }
 
-
-# -- SLGA attribute registry -------------------------------------------------
 
 #' SLGA attribute configuration registry
 #'
@@ -109,6 +152,8 @@ read_slga <- function(
 #' @autoglobal
 #' @dev
 .slga_config <- list(
+  #FIXME: Russell (02/06) Why is the AWC dispatch ID an alphanumeric
+  #  instead of just "slga_awc" like the others?
   "482301c2" = list(dir = "AWC", prefix = "AWC", version = "v2",
                     date = "20210614", suffix = "AU_TRN_N"),
   "slga_cly" = list(dir = "CLY", prefix = "CLY", version = "v2",
@@ -128,9 +173,7 @@ read_slga <- function(
 )
 
 
-# -- Internal SLGA handler ---------------------------------------------------
-
-#' Internal handler for SLGA soil attributes
+#' Internal handler for retrieving SLGA soil attributes
 #'
 #' A generic handler that covers all eight SLGA soil attributes.  Each
 #' attribute has a fixed file-naming pattern encoded in [.slga_config].
@@ -144,13 +187,24 @@ read_slga <- function(
 .read_tern_slga <- function(did, dots, api_key, max_tries, initial_delay) {
   cfg <- .slga_config[[did]]
 
-  depth      <- if (!is.null(dots[["depth"]])) dots[["depth"]] else "000_005"
-  collection <- if (!is.null(dots[["collection"]])) dots[["collection"]] else "EV"
+  depth <- if (!is.null(dots[["depth"]])) {
+    dots[["depth"]]
+  } else {
+    "000_005"
+  }
+  collection <- if (!is.null(dots[["collection"]])){
+    dots[["collection"]]
+  } else {
+    "EV"
+  }
 
-  approved_depths <- c("000_005", "005_015", "015_030",
-                       "030_060", "060_100", "100_200")
+  approved_depths <- c("000_005", "005_015", "015_030", "030_060", "060_100",
+                       "100_200")
   depth <- rlang::arg_match(depth, approved_depths)
 
+  #FIXME: Russell (02/06) as noted by Wasin in Issue #45, the "CI" statistic
+  #  doesn't work. We need to return either of the lower or upper confidence
+  #  interval limits separately.
   approved_stats <- c("EV", "CI")
   collection <- rlang::arg_match(collection, approved_stats)
 

--- a/R/read_slga.R
+++ b/R/read_slga.R
@@ -4,8 +4,8 @@
 #' Grid of Australia (SLGA) datasets from the TERN Data Portal. 14 soil
 #' attributes are available at 90m X 90m spatial resolution across Australia,
 #' each with six standard depth layers (0-5cm, 5-15cm, 15-30cm, 30-60cm,
-#' 60-100cm, 100-200cm) and two statistics (estimated value, confidence
-#' interval).
+#' 60-100cm, 100-200cm) and three statistics (estimated value, and the lower
+#' (05) and upper (95) percentile limits for the confidence interval).
 #'
 #' @section Supported soil attributes:
 #' \describe{
@@ -32,8 +32,9 @@
 #' @param depth One of \code{"000_005"} (default), \code{"005_015"},
 #'   \code{"015_030"}, \code{"030_060"}, \code{"060_100"}, or
 #'   \code{"100_200"}.
-#' @param collection One of \code{"EV"} (estimated value, default) or
-#'   \code{"CI"} (confidence interval).
+#' @param collection One of \code{"EV"} (estimated value, default),
+#'   \code{"05"} (lower percentile limit for the 95% confidence interval) or
+#'   \code{"95"} (upper percentile limit for the confidence interval).
 #' @param api_key A \code{character} string containing your \acronym{TERN}
 #'   \acronym{API} key. Defaults to automatic detection from your
 #'   \code{.Renviron} or \code{.Rprofile}.  See [get_key()] for setup.
@@ -62,7 +63,8 @@
 #' r_awc <- read_slga("AWC", depth = "015_030")
 #'
 #' # Read pH (CaCl2) confidence interval at 30-60 cm
-#' r_phc <- read_slga("PHC", depth = "030_060", collection = "CI")
+#' r_phc_low <- read_slga("PHC", depth = "030_060", collection = "05")
+#' r_phc_up <- read_slga("PHC", depth = "030_060", collection = "95")
 #'
 #' @references
 #' \describe{
@@ -187,6 +189,7 @@ read_slga <- function(
   )
   attribute <- toupper(attribute)
   attribute <- rlang::arg_match(attribute, approved_attrs)
+
   read_tern(
     attribute,
     depth = depth,
@@ -261,7 +264,7 @@ read_slga <- function(
   } else {
     "000_005"
   }
-  collection <- if (!is.null(dots[["collection"]])){
+  collection <- if (!is.null(dots[["collection"]])) {
     dots[["collection"]]
   } else {
     "EV"
@@ -271,10 +274,7 @@ read_slga <- function(
                        "100_200")
   depth <- rlang::arg_match(depth, approved_depths)
 
-  #FIXME: Russell (02/06) as noted by Wasin in Issue #45, the "CI" statistic
-  #  doesn't work. We need to return either of the lower or upper confidence
-  #  interval limits separately. (E.g., return the "05", "95" rasters.)
-  approved_stats <- c("EV", "CI")
+  approved_stats <- c("EV", "05", "95")
   collection <- rlang::arg_match(collection, approved_stats)
 
   fname <- sprintf("%s_%s_%s_N_P_%s_%s.tif",

--- a/R/read_slga.R
+++ b/R/read_slga.R
@@ -1,7 +1,7 @@
 #' Read SLGA Soil Attributes from TERN
 #'
 #' Wrapper around [read_tern()] for retrieving various Soil and Landscape
-#' Grid of Australia (SLGA) datasets from the TERN Data Portal. Eight soil
+#' Grid of Australia (SLGA) datasets from the TERN Data Portal. 14 soil
 #' attributes are available at 90m X 90m spatial resolution across Australia,
 #' each with six standard depth layers (0-5cm, 5-15cm, 15-30cm, 30-60cm,
 #' 60-100cm, 100-200cm) and two statistics (estimated value, confidence
@@ -17,11 +17,18 @@
 #'   \item{\code{"PHC"}}{pH (of 1:5 soil/0.01M CaCl2 extract)}
 #'   \item{\code{"PHW"}}{pH (of 1:5 soil water solution)}
 #'   \item{\code{"NTO"}}{Total Nitrogen (%)}
+#'   \item{\code{"AVP"}}{Available soil Phosphorus (mg/kg)}
+#'   \item{\code{"PTO"}}{Total soil Phosphorus (%)}
+#'   \item{\code{"CEC"}}{Cation Exchange Capacity (meq/100g)}
+#'   \item{\code{"ECE"}}{Effective Cation Exchange Capacity (meq/100g)}
+#'   \item{\code{"DUL"}}{Drained Upper Limit volumetric water content (%)}
+#'   \item{\code{"L15"}}{15 Bar Lower Limit volumetric water content (%)}
 #' }
 #'
 #' @param attribute One of \code{"AWC"}, \code{"CLY"}, \code{"SND"},
-#'   \code{"SLT"}, \code{"BDW"}, \code{"PHC"}, \code{"PHW"}, or
-#'   \code{"NTO"}.
+#'   \code{"SLT"}, \code{"BDW"}, \code{"PHC"}, \code{"PHW"}, \code{"NTO"},
+#'   \code{"AVP"}, \code{"PTO"}, \code{"CEC"}, \code{"ECE"}, \code{"DUL"}, or
+#'   \code{"L15"}.
 #' @param depth One of \code{"000_005"} (default), \code{"005_015"},
 #'   \code{"015_030"}, \code{"030_060"}, \code{"060_100"}, or
 #'   \code{"100_200"}.
@@ -47,7 +54,7 @@
 #' [read_tern()]
 #'
 #' @examplesIf interactive()
-#' # Read clay content at 0-5 cm depth
+#' # Read clay content at 0-5 cm depth (default depth)
 #' r <- read_slga("CLY")
 #' autoplot(r)
 #'
@@ -116,6 +123,52 @@
 #'     \doi{10.25919/pm2n-ww12}.\cr\cr TERN Point-of-truth metadata URL:
 #'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/e9484508-c705-4c23-9195-f26d64b9d4f1>
 #'   }
+#'   \item{**AVP: Available phosphorus**}{
+#'     Zund, P. (2022). Soil and Landscape Grid National Soil Attribute Maps
+#'     - Available Phosphorus (3" resolution) - Release 1. Version 1.0.
+#'     Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/6qzh-b979}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/c6ef289b-1ca8-4e53-b8b4-aa97e4706c63>
+#'   }
+#'   \item{**PTO: Total phosphorus**}{
+#'     Malone, B. & Searle, R. (2024). Soil and Landscape Grid National Soil
+#'     Attribute Maps - Total Phosphorus (3" resolution) - Release 2.
+#'     Version 2. Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/7j78-md43}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/be382e63-5ff6-40a9-930f-c84655a5bd87>
+#'   }
+#'   \item{**CEC: Cation exchange capacity**}{
+#'     Malone, B. (2024). Soil and Landscape Grid National Soil Attribute Maps
+#'     - Cation Exchange Capacity (3" resolution) - Release 1. Version 1.0.
+#'     Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/pkva-gf85}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/5b4b2991-bfa6-41df-be33-7009a5d0a5b0>
+#'   }
+#'   \item{**ECE: Effective cation exchange capacity**}{
+#'     Viscarra Rossel, R., Chen, C., Grundy, M., Searle, R., Clifford, D.,
+#'     Odgers, N., Holmes, K., Griffin, T., Liddicoat, C. & Kidd, D. (2014).
+#'     Soil and Landscape Grid National Soil Attribute Maps - Effective Cation
+#'     Exchange Capacity (3" resolution) - Release 1. Version 1. Terrestrial
+#'     Ecosystem Research Network. (Dataset).
+#'     \doi{10.4225/08/546F091C11777}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/0d27cf8b-6627-4f33-8398-1b525bc1a210>
+#'   }
+#'   \item{**DUL: Drained upper limit volumetric water content**}{
+#'     Searle, R. & Nimalka Somarathna, P. (2022). Soil and Landscape Grid
+#'     National Soil Attribute Maps - Drained Upper Limit Volumetric Water
+#'     Content (Percent) (3 arc second resolution) Version 1. Version 1.0.
+#'     Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/jnvd-3a26}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/de9ddc12-b8e4-4ff2-99c4-390227a848aa>
+#'   }
+#'   \item{**L15: 15 bar lower limit volumetric water content**}{
+#'     Searle, R. & Nimalka Somarathna, P. (2022). Soil and Landscape Grid
+#'     National Soil Attribute Maps - 15 Bar Lower Limit Volumetric Water
+#'     Content (Percent) (3 arc second resolution) Version 1. Version 1.0.
+#'     Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/awp8-nv68}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/4443f5df-a0b2-4352-b44b-83f7feb1e27d>
+#'   }
 #' }
 #'
 #' @autoglobal
@@ -128,7 +181,10 @@ read_slga <- function(
   max_tries = NULL,
   initial_delay = NULL
 ) {
-  approved_attrs <- c("AWC", "CLY", "SND", "SLT", "BDW", "PHC", "PHW", "NTO")
+  approved_attrs <- c(
+    "AWC", "CLY", "SND", "SLT", "BDW", "PHC", "PHW", "NTO", "AVP", "PTO",
+    "CEC", "ECE", "DUL", "L15"
+  )
   attribute <- toupper(attribute)
   attribute <- rlang::arg_match(attribute, approved_attrs)
   read_tern(
@@ -153,7 +209,8 @@ read_slga <- function(
 #' @dev
 .slga_config <- list(
   #FIXME: Russell (02/06) Why is the AWC dispatch ID an alphanumeric
-  #  instead of just "slga_awc" like the others?
+  #  instead of just "slga_awc" like the others? Does anything depend
+  #  on it being this way?
   "482301c2" = list(dir = "AWC", prefix = "AWC", version = "v2",
                     date = "20210614", suffix = "AU_TRN_N"),
   "slga_cly" = list(dir = "CLY", prefix = "CLY", version = "v2",
@@ -169,7 +226,19 @@ read_slga <- function(
   "slga_phw" = list(dir = "PHW", prefix = "PHW", version = "v1",
                     date = "20220520", suffix = "AU_TRN_N"),
   "slga_nto" = list(dir = "NTO", prefix = "NTO", version = "v2",
-                    date = "20231101", suffix = "AU_NAT_C")
+                    date = "20231101", suffix = "AU_NAT_C"),
+  "slga_avp" = list(dir = "AVP", prefix = "AVP", version = "v1",
+                    date = "20220826", suffix = "AU_TRN_N"),
+  "slga_pto" = list(dir = "PTO", prefix = "PTO", version = "v2",
+                    date = "20231101", suffix = "AU_NAT_C"),
+  "slga_cec" = list(dir = "CEC", prefix = "CEC", version = "v1",
+                    date = "20220826", suffix = "AU_TRN_N"),
+  "slga_ece" = list(dir = "ECE", prefix = "ECE", version = "v1",
+                    date = "20140801", suffix = "AU_NAT_C"),
+  "slga_dul" = list(dir = "DUL", prefix = "DUL", version = "v1",
+                    date = "20210614", suffix = "AU_TRN_N"),
+  "slga_l15" = list(dir = "L15", prefix = "L15", version = "v1",
+                    date = "20210614", suffix = "AU_TRN_N")
 )
 
 
@@ -204,7 +273,7 @@ read_slga <- function(
 
   #FIXME: Russell (02/06) as noted by Wasin in Issue #45, the "CI" statistic
   #  doesn't work. We need to return either of the lower or upper confidence
-  #  interval limits separately.
+  #  interval limits separately. (E.g., return the "05", "95" rasters.)
   approved_stats <- c("EV", "CI")
   collection <- rlang::arg_match(collection, approved_stats)
 

--- a/R/read_slga.R
+++ b/R/read_slga.R
@@ -211,36 +211,33 @@ read_slga <- function(
 #' @autoglobal
 #' @dev
 .slga_config <- list(
-  #FIXME: Russell (02/06) Why is the AWC dispatch ID an alphanumeric
-  #  instead of just "slga_awc" like the others? Does anything depend
-  #  on it being this way?
   "482301c2" = list(dir = "AWC", prefix = "AWC", version = "v2",
                     date = "20210614", suffix = "AU_TRN_N"),
-  "slga_cly" = list(dir = "CLY", prefix = "CLY", version = "v2",
+  "f95dc442" = list(dir = "CLY", prefix = "CLY", version = "v2",
                     date = "20210902", suffix = "AU_TRN_N"),
-  "slga_snd" = list(dir = "SND", prefix = "SND", version = "v2",
+  "4224ddff" = list(dir = "SND", prefix = "SND", version = "v2",
                     date = "20210902", suffix = "AU_TRN_N"),
-  "slga_slt" = list(dir = "SLT", prefix = "SLT", version = "v2",
+  "11375f04" = list(dir = "SLT", prefix = "SLT", version = "v2",
                     date = "20210902", suffix = "AU_TRN_N"),
-  "slga_bdw" = list(dir = "BDW", prefix = "BDW", version = "v2",
+  "95978aec" = list(dir = "BDW", prefix = "BDW", version = "v2",
                     date = "20230607", suffix = "AU_TRN_N"),
-  "slga_phc" = list(dir = "pHc", prefix = "PHC", version = "v2",
+  "258afc98" = list(dir = "pHc", prefix = "PHC", version = "v2",
                     date = "20210913", suffix = "AU_NAT_C"),
-  "slga_phw" = list(dir = "PHW", prefix = "PHW", version = "v1",
+  "c37439a5" = list(dir = "PHW", prefix = "PHW", version = "v1",
                     date = "20220520", suffix = "AU_TRN_N"),
-  "slga_nto" = list(dir = "NTO", prefix = "NTO", version = "v2",
+  "e9484508" = list(dir = "NTO", prefix = "NTO", version = "v2",
                     date = "20231101", suffix = "AU_NAT_C"),
-  "slga_avp" = list(dir = "AVP", prefix = "AVP", version = "v1",
+  "c6ef289b" = list(dir = "AVP", prefix = "AVP", version = "v1",
                     date = "20220826", suffix = "AU_TRN_N"),
-  "slga_pto" = list(dir = "PTO", prefix = "PTO", version = "v2",
+  "be382e63" = list(dir = "PTO", prefix = "PTO", version = "v2",
                     date = "20231101", suffix = "AU_NAT_C"),
-  "slga_cec" = list(dir = "CEC", prefix = "CEC", version = "v1",
+  "5b4b2991" = list(dir = "CEC", prefix = "CEC", version = "v1",
                     date = "20220826", suffix = "AU_TRN_N"),
-  "slga_ece" = list(dir = "ECE", prefix = "ECE", version = "v1",
+  "0d27cf8b" = list(dir = "ECE", prefix = "ECE", version = "v1",
                     date = "20140801", suffix = "AU_NAT_C"),
-  "slga_dul" = list(dir = "DUL", prefix = "DUL", version = "v1",
+  "de9ddc12" = list(dir = "DUL", prefix = "DUL", version = "v1",
                     date = "20210614", suffix = "AU_TRN_N"),
-  "slga_l15" = list(dir = "L15", prefix = "L15", version = "v1",
+  "4443f5df" = list(dir = "L15", prefix = "L15", version = "v1",
                     date = "20210614", suffix = "AU_TRN_N")
 )
 

--- a/R/read_smips.R
+++ b/R/read_smips.R
@@ -1,76 +1,80 @@
 #' Read TERN SMIPS Soil Moisture Data
 #'
 #' @description
-#' Wrapper around [read_tern()] for TERN/SMIPS daily soil moisture data.
-#' Provides soil moisture estimates at 1 km resolution from November 2015
-#' to approximately 7 days before today.
+#' Wrapper around [read_tern()] for retrieving the SMIPS v1.0 daily soil
+#' moisture data from the TERN Data Portal. SMIPS provides soil moisture
+#' estimates at roughly 1km X 1km spatial resolution across Australia,
+#' from 1st January 2015 to approximately 7 days before today.
 #'
 #' @param date A day to download (Date or character, e.g.
-#'   \code{"2024-01-15"} or \code{as.Date("2024-01-15")}).  Required.
+#'   \code{"2024-01-15"} or \code{as.Date("2024-01-15")}).
 #' @param collection SMIPS collection variant (default \code{"totalbucket"}). Options:
 #'   \describe{
-#'     \item{\code{"totalbucket"}}{**Total soil moisture in the full active layer** (mm).
-#'       Represents the total water stored in all soil layers of the active profile.
-#'       Use for: Overall soil water availability, drought monitoring.
-#'       Output column: \code{SMIPS_totalbucket}}
-#'     \item{\code{"SMindex"}}{**Soil Moisture Index, 0-100%** (standardized metric).
-#'       Rescaled to 0-100% for comparison across regions and seasons.
-#'       Use for: Regional comparisons, anomaly detection, percentage-based thresholds.
-#'       Output column: \code{SMIPS_SMindex}}
-#'     \item{\code{"bucket1"}}{**Top soil layer moisture** (mm, typically 0-10 cm).
-#'       Represents water in surface soil where seeds germinate and shallow roots operate.
-#'       Use for: Shallow-rooting plants, seed germination, surface runoff prediction.
-#'       Output column: \code{SMIPS_bucket1}}
-#'     \item{\code{"bucket2"}}{**Second soil layer moisture** (mm, typically 10-40 cm).
-#'       Represents water in intermediate soil depth where many plant roots develop.
-#'       Use for: Typical crop rooting depth, plant-available water.
-#'       Output column: \code{SMIPS_bucket2}}
-#'     \item{\code{"deepD"}}{**Deep soil layer moisture** (mm, typically >40 cm).
-#'       Represents water in deeper soil layers accessed by deep-rooting plants.
-#'       Use for: Deep-rooting trees/shrubs, groundwater recharge, long-term drought.
-#'       Output column: \code{SMIPS_deepD}}
-#'     \item{\code{"runoff"}}{**Surface runoff** (mm).
-#'       Represents water predicted to run off the surface (not infiltrate).
-#'       Use for: Flood risk, erosion modeling, drainage engineering.
-#'       Output column: \code{SMIPS_runoff}}
+#'     \item{\code{"totalbucket"}}{**Soil moisture of the 0-90cm two-bucket store** (mm).
+#'       An estimate of the volumetric soil moisture of the complete 0-90cm
+#'       SMIPS two-bucket soil moisture store.}
+#'     \item{\code{"SMindex"}}{**Soil moisture index, 0-1**.
+#'       A unitless index between 0.0 and 1.0, approximating how full the
+#'       complete SMIPS 0-90cm soil moisture two-bucket store is.}
+#'     \item{\code{"bucket1"}}{**Soil moisture in the upper 0-10cm bucket** (mm).
+#'       An estimate of the volumetric soil moisture of the upper 0-10cm
+#'       soil bucket.}
+#'     \item{\code{"bucket2"}}{**Soil moisture in the lower 10-90cm bucket** (mm).
+#'       An estimate of the volumetric soil moisture of the lower 10-90cm
+#'       soil bucket.}
+#'     \item{\code{"deepD"}}{**Drainage between two buckets** (mm).
+#'       An estimate of the drainage from the top 0-1cm soil bucket through
+#'       to the lower 10-90cm bucket.}
+#'     \item{\code{"runoff"}}{**Runoff/overtopping moisture loss** (mm).
+#'       An estimate of the moisture lost from the top 0-10cm bucket due to
+#'       runoff or overtopping.}
 #'   }
 #' @param api_key A \code{character} string containing your \acronym{TERN}
 #'   \acronym{API} key.  Defaults to automatic detection from your
 #'   \code{.Renviron} or \code{.Rprofile}.  See [get_key()] for setup.
 #' @param max_tries Maximum number of download retries before an error is
-#'   raised.  When \code{NULL} (default), resolved from
-#'   \code{getOption("nert.max_tries", 3L)}.  Pass an integer to override
-#'   for a single call.
+#'   raised. Default=\code{NULL}, in which case the maximum retry number is
+#'   resolved from the option \code{nert.max_tries} if that option exists.
+#'   (Defaults to 3 retries if \code{nert.max_tries} has not been set.)
 #' @param initial_delay Initial retry delay in seconds (doubles with each
-#'   attempt).  When \code{NULL} (default), resolved from
-#'   \code{getOption("nert.initial_delay", 1L)}.  Pass an integer to
-#'   override for a single call.
+#'   attempt). Default=\code{NULL}, in which case the initial delay is
+#'   resolved from the option \code{nert.initial_delay} if that option exists.
+#'   (Defaults to a 1 second initial delay if \code{nert.initial_delay} has
+#'   not been set.)
 #'
 #' @returns
-#' A [terra::rast()] object of the requested SMIPS collection.
+#' A [terra::SpatRaster] object of the requested SMIPS collection.
 #'
 #' @seealso
-#' [read_tern()], [read_aet()], [read_asc()]
+#' [read_tern()]
 #'
 #' @examplesIf interactive()
-#' # Total bucket soil moisture (default)
+#' # Total volumetric soil moisture across both buckets (default)
 #' r <- read_smips("2024-01-15")
 #' autoplot(r)
 #'
-#' # Soil moisture index (0-100%)
+#' # Soil moisture index (0-1)
 #' r_smi <- read_smips("2024-01-15", collection = "SMindex")
 #'
-#' # Top soil bucket (shallow rooting plants)
+#' # Upper soil bucket
 #' r_bucket1 <- read_smips("2024-01-15", collection = "bucket1")
 #'
-#' # Deep soil layer (deep rooting plants)
+#' # Lower soil bucket
+#' r_bucket2 <- read_smips("2024-01-15", collection = "bucket2")
+#'
+#' # Drainage between upper and lower buckets
 #' r_deep <- read_smips("2024-01-15", collection = "deepD")
 #'
-#' # Surface runoff
+#' # Top bucket runoff
 #' r_runoff <- read_smips("2024-01-15", collection = "runoff")
 #'
 #' @references
-#'   SMIPS portal:
+#'   Stenson, M., Searle, R., Malone, B., Sommer, A., Renzullo, L. & Di, H.
+#'   (2021): Australia wide daily volumetric soil moisture estimates.
+#'   Version 1.0. Terrestrial Ecosystem Research Network. (Dataset).
+#'   \doi{10.25901/b020-nm39}.
+#'
+#'   TERN SMIPS Point-of-truth metadata URL:
 #'   <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/d1995ee8-53f0-4a7d-91c2-ad5e4a23e5e0>
 #'
 #' @autoglobal
@@ -78,24 +82,22 @@
 read_smips <- function(
   date,
   collection = "totalbucket",
-  api_key    = NULL,
-  max_tries  = NULL,
+  api_key = NULL,
+  max_tries = NULL,
   initial_delay = NULL
 ) {
   read_tern(
     "SMIPS",
-    date       = date,
+    date = date,
     collection = collection,
-    api_key    = api_key,
-    max_tries  = max_tries,
+    api_key = api_key,
+    max_tries = max_tries,
     initial_delay = initial_delay
   )
 }
 
 
-# -- Internal SMIPS handler --------------------------------------------------
-
-#' Internal handler for SMIPS (\code{TERN/d1995ee8})
+#' Internal handler for retrieving SMIPS datasets
 #'
 #' @param dots Named list of \code{...} args from [read_tern()].
 #' @param api_key URL-encoded API key.
@@ -104,11 +106,15 @@ read_smips <- function(
 #' @dev
 .read_tern_smips <- function(dots, api_key, max_tries, initial_delay) {
   # Accept both 'date' and the legacy 'day' parameter name
-  date <- if (!is.null(dots[["date"]])) dots[["date"]] else dots[["day"]]
+  date <- if (!is.null(dots[["date"]])) {
+    dots[["date"]]
+  } else {
+    dots[["day"]]
+  }
   if (is.null(date)) {
     cli::cli_abort(
       "SMIPS requires a {.arg date} argument (daily resolution),
-       e.g.  {.code date = \"2024-01-15\"}."
+       e.g. {.code date = \"2024-01-15\"}."
     )
   }
   collection <- if (!is.null(dots[["collection"]])) {
@@ -130,15 +136,14 @@ read_smips <- function(
 }
 
 
-# -- SMIPS date-window and URL helpers --------------------------------------
-
-#' Validate Days Requested Align With Collection
+#' Validate date requested aligns with SMIPS collection extent
 #'
-#' SMIPS daily COGs are published from 2015-11-20 (the earliest archived
-#' national mosaic on the TERN portal) up to approximately seven days before
-#' today.  Requests outside that window return HTTP 404 from the GDAL vsicurl
-#' driver, which surfaces as an opaque "file does not exist" error from
-#' [terra::rast()].  This helper catches that case before any network I/O.
+#' SMIPS daily COGs are published from 2015-01-01 (the earliest archived
+#' complete set of soil moisture GeoTIFFs available on the TERN Data Portal),
+#' up to approximately seven days before today.  Requests outside that
+#' window will return HTTP 404 from the GDAL vsicurl driver, resulting in a
+#' "file does not exist" error from [terra::rast()].  This helper function
+#' catches this case before any network I/O.
 #'
 #' @param .collection The user-supplied SMIPS collection being asked for.
 #' @param .day The user-supplied date being asked for.
@@ -147,14 +152,20 @@ read_smips <- function(
 #'
 #' @dev
 .check_collection_agreement <- function(.collection, .day) {
-  smips_start <- as.Date("2015-11-20")
-  last_week   <- lubridate::today() - 7L
-  day_d       <- as.Date(.day)
+  smips_start <- as.Date("2015-01-01")
+
+  #FIXME Russell (01/06): As explained in issue #46, I don't think we need
+  #  to bother with checking this upper bound (or just make it today's date).
+  #  The mythical "7-day publishing delay" appears to be an AI fabrication.
+  last_week <- lubridate::today() - 7L
+
+  day_d <- as.Date(.day)
 
   if (day_d < smips_start) {
     cli::cli_abort(
-      "SMIPS data are not available before {format(smips_start, '%Y-%m-%d')}. \\
-       You requested {format(day_d, '%Y-%m-%d')}."
+      "SMIPS data are not generally available before
+      {format(smips_start, '%Y-%m-%d')}. \\
+      You requested {format(day_d, '%Y-%m-%d')}."
     )
   }
   if (day_d > last_week) {
@@ -166,7 +177,8 @@ read_smips <- function(
   }
 }
 
-#' Create an SMIPS URL
+
+#' Create a SMIPS URL
 #'
 #' Creates the SMIPS specific portion of a URL to read or fetch a COG.
 #'
@@ -174,7 +186,6 @@ read_smips <- function(
 #' @param .day The user-supplied date being asked for.
 #'
 #' @autoglobal
-#' @dev
 #' @dev
 .make_smips_url <- function(.collection, .day) {
   url_date <- gsub("-", "", .day, fixed = TRUE)

--- a/R/read_smips.R
+++ b/R/read_smips.R
@@ -4,7 +4,8 @@
 #' Wrapper around [read_tern()] for retrieving the SMIPS v1.0 daily soil
 #' moisture data from the TERN Data Portal. SMIPS provides soil moisture
 #' estimates at roughly 1km X 1km spatial resolution across Australia,
-#' from 1st January 2015 to approximately 7 days before today.
+#' from 1st January 2015 onward (updated approximately daily on the TERN
+#' server).
 #'
 #' @param date A day to download (Date or character, e.g.
 #'   \code{"2024-01-15"} or \code{as.Date("2024-01-15")}).
@@ -102,6 +103,7 @@ read_smips <- function(
 #' @param dots Named list of \code{...} args from [read_tern()].
 #' @param api_key URL-encoded API key.
 #' @param max_tries,initial_delay Passed to [.read_cog()].
+#'
 #' @autoglobal
 #' @dev
 .read_tern_smips <- function(dots, api_key, max_tries, initial_delay) {
@@ -140,39 +142,37 @@ read_smips <- function(
 #'
 #' SMIPS daily COGs are published from 2015-01-01 (the earliest archived
 #' complete set of soil moisture GeoTIFFs available on the TERN Data Portal),
-#' up to approximately seven days before today.  Requests outside that
-#' window will return HTTP 404 from the GDAL vsicurl driver, resulting in a
-#' "file does not exist" error from [terra::rast()].  This helper function
-#' catches this case before any network I/O.
+#' up to today. Requests outside that window will definitely return HTTP 404
+#' from the GDAL vsicurl driver, resulting in a "file does not exist" error
+#' from [terra::rast()].  This helper function catches this case before
+#' any network I/O. (Note: the requested rasters may still be unavailable
+#' even if this check passes, e.g., if the user has requested a very recent
+#' raster that has not been added to the TERN server yet. This validation
+#' function simply checks for the obviously impossible cases.)
 #'
 #' @param .collection The user-supplied SMIPS collection being asked for.
 #' @param .day The user-supplied date being asked for.
 #'
 #' @autoglobal
-#'
 #' @dev
 .check_collection_agreement <- function(.collection, .day) {
+  # Convert everything to Date objects to enable simple and sane comparison
   smips_start <- as.Date("2015-01-01")
+  .day <- as.Date(as.character(.day))
+  smips_end <- Sys.Date()
 
-  #FIXME Russell (01/06): As explained in issue #46, I don't think we need
-  #  to bother with checking this upper bound (or just make it today's date).
-  #  The mythical "7-day publishing delay" appears to be an AI fabrication.
-  last_week <- lubridate::today() - 7L
-
-  day_d <- as.Date(.day)
-
-  if (day_d < smips_start) {
+  if (.day < smips_start) {
     cli::cli_abort(
       "SMIPS data are not generally available before
       {format(smips_start, '%Y-%m-%d')}. \\
-      You requested {format(day_d, '%Y-%m-%d')}."
+      You requested {format(.day, '%Y-%m-%d')}."
     )
   }
-  if (day_d > last_week) {
+  if (.day > smips_end) {
     cli::cli_abort(
-      "SMIPS publishes with a roughly seven-day delay; the most recent date \\
-       available is {format(last_week, '%Y-%m-%d')}. You requested \\
-       {format(day_d, '%Y-%m-%d')}."
+      "SMIPS data are not yet available for dates beyond
+      {format(smips_end, '%Y-%m-%d')}. \\
+      You requested {format(.day, '%Y-%m-%d')}."
     )
   }
 }
@@ -199,7 +199,6 @@ read_smips <- function(
     "runoff"
   )
   collection <- rlang::arg_match(.collection, approved_collections)
-
   .check_collection_agreement(.collection = .collection, .day = .day)
 
   collection_url <- data.table::fcase(

--- a/R/read_smips.R
+++ b/R/read_smips.R
@@ -1,4 +1,4 @@
-#' Read TERN SMIPS Soil Moisture Data
+#' Read SMIPS Soil Moisture Data from TERN
 #'
 #' @description
 #' Wrapper around [read_tern()] for retrieving the SMIPS v1.0 daily soil
@@ -30,7 +30,7 @@
 #'       runoff or overtopping.}
 #'   }
 #' @param api_key A \code{character} string containing your \acronym{TERN}
-#'   \acronym{API} key.  Defaults to automatic detection from your
+#'   \acronym{API} key. Defaults to automatic detection from your
 #'   \code{.Renviron} or \code{.Rprofile}.  See [get_key()] for setup.
 #' @param max_tries Maximum number of download retries before an error is
 #'   raised. Default=\code{NULL}, in which case the maximum retry number is

--- a/R/read_soil_diversity.R
+++ b/R/read_soil_diversity.R
@@ -1,37 +1,34 @@
 #' Read Soil Beta Diversity from TERN
 #'
-#' Read Soil Beta Diversity Cloud Optimised GeoTIFF (\acronym{COG}) files
-#' from \acronym{TERN}.  This product provides Non-metric Multidimensional
-#' Scaling (\acronym{NMDS}) axes 1--3 for soil Bacteria and Fungi
-#' communities across Australia at 90 m resolution.
-#'
-#' @section Collections:
-#' \describe{
-#'   \item{\code{"Bacteria"}}{Bacterial community beta diversity (default).}
-#'   \item{\code{"Fungi"}}{Fungal community beta diversity.}
-#' }
-#'
-#' This is a static product (no date argument required).
-#'
-#' This is a convenience wrapper around
-#' \code{read_tern("SOILDIV", ...)}; see [read_tern()] for full
-#' details and additional datasets.
+#' Wrapper around [read_tern()] for retrieving the v1.0 datasets for
+#' soil bacteria and soil fungi Beta Diversity from the TERN Data Portal.
+#' The Beta Diversity datasets were constructed using Digital Soil Mapping
+#' techniques together with Biome of Australia Soil Environments (BASE)
+#' DNA sequences, and provide Non-metric MultiDimensional Scaling (NMDS)
+#' axes for soil bacteria and fungi at 90m X 90m spatial resolution across
+#' Australia.
 #'
 #' @param collection One of \code{"Bacteria"} (default) or \code{"Fungi"}.
 #' @param axis \acronym{NMDS} axis number: \code{1} (default), \code{2}, or
 #'   \code{3}.
 #' @param api_key A \code{character} string containing your \acronym{TERN}
-#'   \acronym{API} key.  Defaults to automatic detection via [get_key()].
+#'   \acronym{API} key. Defaults to automatic detection from your
+#'   \code{.Renviron} or \code{.Rprofile}. See [get_key()] for setup.
 #' @param max_tries Maximum number of download retries before an error is
-#'   raised.  When \code{NULL} (default), resolved from
-#'   \code{getOption("nert.max_tries", 3L)}.  Pass an integer to override
-#'   for a single call.
+#'   raised. Default=\code{NULL}, in which case the maximum retry number is
+#'   resolved from the option \code{nert.max_tries} if that option exists.
+#'   (Defaults to 3 retries if \code{nert.max_tries} has not been set.)
 #' @param initial_delay Initial retry delay in seconds (doubles with each
-#'   attempt).  When \code{NULL} (default), resolved from
-#'   \code{getOption("nert.initial_delay", 1L)}.  Pass an integer to
-#'   override for a single call.
+#'   attempt). Default=\code{NULL}, in which case the initial delay is
+#'   resolved from the option \code{nert.initial_delay} if that option exists.
+#'   (Defaults to a 1 second initial delay if \code{nert.initial_delay} has
+#'   not been set.)
 #'
-#' @family COGs
+#' @returns
+#' A [terra::SpatRaster] object of the requested Beta Diversity NMDS axis.
+#'
+#' @seealso
+#' [read_tern()]
 #'
 #' @examplesIf interactive()
 #' # Read bacterial diversity NMDS axis 1
@@ -42,35 +39,36 @@
 #' r_f2 <- read_soil_diversity(collection = "Fungi", axis = 2)
 #' autoplot(r_f2)
 #'
-#' @returns A [terra::rast()] object of the national Soil Beta Diversity
-#'   mosaic for the requested organism and NMDS axis.
-#'
 #' @references
-#'   <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/4a428d52-d15c-4bfc-8a67-80697f8c0aa0>
+#'   Dobarco, M., Wadoux, A. & Xue, P. (2024). Soil and Landscape Grid National
+#'   Soil Attribute Maps - Soil Bacteria and Fungi Beta Diversity (3"
+#'   resolution) - Release 1. Version 1.0. Terrestrial Ecosystem Research
+#'   Network. (Dataset). \doi{10.25919/4x7n-y874}.
+#'
+#'   TERN Soil Beta Diversity Point-of-truth metadata URL:
+#'   <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/4a428d52-dda6-4097-8dd9-d3ec63973029>
 #'
 #' @autoglobal
 #' @export
 read_soil_diversity <- function(
-  collection    = "Bacteria",
-  axis          = 1L,
-  api_key       = get_key(),
-  max_tries     = NULL,
+  collection = "Bacteria",
+  axis = 1L,
+  api_key = get_key(),
+  max_tries = NULL,
   initial_delay = NULL
 ) {
   read_tern(
     "SOILDIV",
-    collection    = collection,
-    axis          = axis,
-    api_key       = api_key,
-    max_tries     = max_tries,
+    collection = collection,
+    axis = axis,
+    api_key = api_key,
+    max_tries = max_tries,
     initial_delay = initial_delay
   )
 }
 
 
-# -- Internal Soil Beta Diversity handler -----------------------------------
-
-#' Internal handler for Soil Beta Diversity (\code{TERN/4a428d52})
+#' Internal handler for retrieving Soil Beta Diversity datasets
 #'
 #' @param dots Named list of \code{...} args from [read_tern()].
 #' @param api_key URL-encoded API key.
@@ -78,8 +76,16 @@ read_soil_diversity <- function(
 #' @autoglobal
 #' @dev
 .read_tern_soil_diversity <- function(dots, api_key, max_tries, initial_delay) {
-  collection <- if (!is.null(dots[["collection"]])) dots[["collection"]] else "Bacteria"
-  axis       <- if (!is.null(dots[["axis"]])) as.integer(dots[["axis"]]) else 1L
+  collection <- if (!is.null(dots[["collection"]])) {
+    dots[["collection"]]
+  } else {
+    "Bacteria"
+  }
+  axis <- if (!is.null(dots[["axis"]])) {
+    as.integer(dots[["axis"]])
+  } else {
+    1L
+  }
 
   approved_collections <- c("Bacteria", "Fungi")
   collection <- rlang::arg_match(collection, approved_collections)

--- a/R/read_tern.R
+++ b/R/read_tern.R
@@ -4,28 +4,34 @@
 #' data from \acronym{TERN} and related repositories.  Dispatches to a
 #' dataset-specific handler based on \code{dataset_id} and passes any
 #' additional arguments through \code{...}.  The returned object is a
-#' [terra::rast()] that can be plotted, cropped, or extracted with standard
-#' \pkg{terra} or \pkg{tidyterra} workflows.
+#' [terra::SpatRaster] that can be plotted, cropped, or extracted with
+#' standard \pkg{terra} or \pkg{tidyterra} workflows.
 #'
 #' @section Dataset aliases:
 #' In addition to full \acronym{TERN} portal keys and 8-character prefixes,
 #' \code{read_tern()} accepts short human-readable aliases (case-insensitive):
 #' \tabular{lll}{
-#'   \strong{Alias}        \tab \strong{Dataset ID}        \tab \strong{Description} \cr
-#'   \code{"SMIPS"}         \tab \code{TERN/d1995ee8} \tab Daily soil moisture (~1 km) \cr
-#'   \code{"ASC"}           \tab \code{TERN/15728dba} \tab Australian Soil Classification (90 m) \cr
-#'   \code{"AET"}           \tab \code{TERN/9fefa68b} \tab Monthly evapotranspiration (CMRSET) \cr
-#'   \code{"AWC"}           \tab \code{TERN/482301c2} \tab Available Water Capacity (90 m) \cr
-#'   \code{"CLY"}           \tab SLGA                 \tab Clay content (90 m) \cr
-#'   \code{"SND"}           \tab SLGA                 \tab Sand content (90 m) \cr
-#'   \code{"SLT"}           \tab SLGA                 \tab Silt content (90 m) \cr
-#'   \code{"BDW"}           \tab SLGA                 \tab Bulk density whole earth (90 m) \cr
-#'   \code{"PHC"}           \tab SLGA                 \tab pH CaCl2 (90 m) \cr
-#'   \code{"PHW"}           \tab SLGA                 \tab pH water (90 m) \cr
-#'   \code{"NTO"}           \tab SLGA                 \tab Total Nitrogen (90 m) \cr
-#'   \code{"SOILDIV"}       \tab \code{TERN/4a428d52} \tab Soil Beta Diversity (90 m) \cr
-#'   \code{"CANOPY"}        \tab \code{TERN/36c98155} \tab Canopy Height (30 m) \cr
-#'   \code{"PHENOLOGY"}     \tab \code{TERN/2bb0c81a} \tab Land Surface Phenology (500 m) \cr
+#'   \strong{Alias} \tab \strong{Dataset ID} \tab \strong{Description} \cr
+#'   \code{"SMIPS"} \tab \code{TERN/d1995ee8} \tab Daily soil moisture (~1 km) \cr
+#'   \code{"ASC"} \tab \code{TERN/15728dba} \tab Australian Soil Classification (90 m) \cr
+#'   \code{"AET"} \tab \code{TERN/9fefa68b} \tab Monthly evapotranspiration (CMRSET) \cr
+#'   \code{"AWC"} \tab \code{TERN/482301c2} \tab Available Water Capacity (90 m) \cr
+#'   \code{"CLY"} \tab SLGA \tab Clay content (90 m) \cr
+#'   \code{"SND"} \tab SLGA \tab Sand content (90 m) \cr
+#'   \code{"SLT"} \tab SLGA \tab Silt content (90 m) \cr
+#'   \code{"BDW"} \tab SLGA \tab Bulk density whole earth (90 m) \cr
+#'   \code{"PHC"} \tab SLGA \tab pH CaCl2 (90 m) \cr
+#'   \code{"PHW"} \tab SLGA \tab pH water (90 m) \cr
+#'   \code{"NTO"} \tab SLGA \tab Total Nitrogen (90 m) \cr
+#'   \code{"AVP"} \tab SLGA \tab Available Phosphorus (90 m) \cr
+#'   \code{"PTO"} \tab SLGA \tab Total Phosphorus (90 m) \cr
+#'   \code{"CEC"} \tab SLGA \tab Cation Exchange Capacity (90 m) \cr
+#'   \code{"ECE"} \tab SLGA \tab Effective Cation Exchange Capacity (90 m) \cr
+#'   \code{"DUL"} \tab SLGA \tab Drained Upper Limit water content (90 m) \cr
+#'   \code{"L15"} \tab SLGA \tab 15 Bar Lower Limit water content (90 m) \cr
+#'   \code{"SOILDIV"} \tab \code{TERN/4a428d52} \tab Soil Beta Diversity (90 m) \cr
+#'   \code{"CANOPY"} \tab \code{TERN/36c98155} \tab Canopy Height (30 m) \cr
+#'   \code{"PHENOLOGY"} \tab \code{TERN/2bb0c81a} \tab Land Surface Phenology (500 m) \cr
 #' }
 #' Convenience wrappers [read_smips()], [read_asc()], [read_aet()],
 #' [read_slga()], [read_soil_diversity()], [read_canopy_height()], and
@@ -40,13 +46,13 @@
 #'     \code{"SMindex"}, \code{"bucket1"}, \code{"bucket2"},
 #'     \code{"deepD"}, or \code{"runoff"}.}
 #' }
-#' Data availability: 2015-11-20 to approximately 7 days before today.
+#' Data availability: 2015-01-01 to approximately 7 days before today.
 #'
 #' @section ASC -- Australian Soil Classification (\code{"TERN/15728dba"}):
 #' \describe{
 #'   \item{\code{collection}}{One of \code{"EV"} (estimated soil order
 #'     class, default) or \code{"CI"} (confusion index -- a measure of
-#'     mapping reliability).  No \code{date} argument required; this is a
+#'     mapping uncertainty).  No \code{date} argument required; this is a
 #'     static product.}
 #' }
 #'
@@ -59,10 +65,10 @@
 #'   \item{\code{collection}}{One of \code{"ETa"} (primary AET band in
 #'     mm/month, default) or \code{"pixel_qa"} (quality assurance flags).}
 #' }
-#' Data availability: 2000-02-01 onwards.
+#' Data availability: 1987-05-01 onwards.
 #'
 #' @section SLGA soil attributes (\code{"AWC"}, \code{"CLY"}, etc.):
-#' Eight \acronym{SLGA} (Soil and Landscape Grid of Australia) soil
+#' 14 \acronym{SLGA} (Soil and Landscape Grid of Australia) soil
 #' attributes are available as static 90 m products, each with six standard
 #' depth layers and two statistics:
 #' \describe{
@@ -74,7 +80,7 @@
 #' }
 #' Supported attributes (use as the \code{dataset_id} alias):
 #' \describe{
-#'   \item{\code{"AWC"}}{Available Water Capacity (mm)}
+#'   \item{\code{"AWC"}}{Available Water Capacity (percent)}
 #'   \item{\code{"CLY"}}{Clay content (percent)}
 #'   \item{\code{"SND"}}{Sand content (percent)}
 #'   \item{\code{"SLT"}}{Silt content (percent)}
@@ -82,6 +88,12 @@
 #'   \item{\code{"PHC"}}{pH (CaCl2)}
 #'   \item{\code{"PHW"}}{pH (water)}
 #'   \item{\code{"NTO"}}{Total Nitrogen (percent)}
+#'   \item{\code{"AVP"}}{Available Phosphorus (mg/kg)}
+#'   \item{\code{"PTO"}}{Total Phosphorus (percent)}
+#'   \item{\code{"CEC"}}{Cation Exchange Capacity (meq/100g)}
+#'   \item{\code{"ECE"}}{Effective Cation Exchange Capacity (meq/100g)}
+#'   \item{\code{"DUL"}}{Drained Upper Limit volumetric water content (percent)}
+#'   \item{\code{"L15"}}{15 Bar Lower Limit volumetric water content (percent)}
 #' }
 #' Convenience wrapper: [read_slga()].
 #'
@@ -95,21 +107,22 @@
 #' Static 90 m product.  Convenience wrapper: [read_soil_diversity()].
 #'
 #' @section Canopy Height (\code{"CANOPY"}, \code{TERN/36c98155}):
-#' Single static 30 m composite from the OzTreeMap project.  No additional
-#' arguments required.  Convenience wrapper: [read_canopy_height()].
+#' Single static 30 m best-pick composite from the OzTreeMap project.
+#' No additional arguments required.
+#' Convenience wrapper: [read_canopy_height()].
 #'
 #' @section Land Surface Phenology (\code{"PHENOLOGY"}, \code{TERN/2bb0c81a}):
 #' \describe{
 #'   \item{\code{year}}{Required.  An integer year (2003--2018).}
 #'   \item{\code{season}}{Season number: \code{1} (default) or \code{2}.}
 #'   \item{\code{collection}}{Phenology metric — one of \code{"SGS"}
-#'     (Start of Growing Season, default), \code{"PGS"} (Peak),
-#'     \code{"EGS"} (End), \code{"LGS"} (Length), \code{"SOS"} (Start of
-#'     Season), \code{"POS"} (Peak of Season), \code{"EOS"} (End of Season),
-#'     \code{"LOS"} (Length of Season), \code{"ROG"} (Rate of Greening),
-#'     \code{"ROS"} (Rate of Senescence).}
+#'     (Start of Growing Season, default), \code{"PGS"} (Peak of Growing Season),
+#'     \code{"EGS"} (End of Growing Season), \code{"LGS"} (Length of Growing Season),
+#'     \code{"EVI1"} (Minimum EVI before peak), \code{"EVI2"} (Minimum EVI after peak),
+#'     \code{"EVIP"} (EVI at Peak of Growing Season),
+#'     \code{"EVII"} (Integral of EVI under growing season curve).}
 #' }
-#' 500 m MODIS resolution.  Convenience wrapper: [read_phenology()].
+#' 500 m resolution.  Convenience wrapper: [read_phenology()].
 #'
 #' @section Datasets not accessible:
 #' The following datasets are tracked in the \acronym{TERN} catalogue but
@@ -159,12 +172,9 @@
 #' \preformatted{
 #'   options(nert.max_tries = 5L, nert.initial_delay = 2L)
 #' }
-#' Closes \href{https://github.com/AAGI-AUS/nert/issues/20}{AAGI-AUS/nert#20}.
-#'
-#' @family COGs
 #'
 #' @examplesIf interactive()
-#' # Using aliases (recommended) ----------------------------------------
+#' # Using aliases (recommended)
 #' r <- read_tern("SMIPS", date = "2024-01-15")
 #' r_asc <- read_tern("ASC")
 #' autoplot(r_asc)
@@ -182,25 +192,19 @@
 #' # Land Surface Phenology
 #' r_phen <- read_tern("PHENOLOGY", year = 2018, collection = "SGS")
 #'
-#' # Full TERN keys still work ----------------------------------------
+#' # Full TERN keys still work
 #' r2 <- read_tern("TERN/d1995ee8", date = "2024-01-15")
 #'
-#' @returns A [terra::rast()] object of the national mosaic for the
+#' @returns A [terra::SpatRaster] object of the national mosaic for the
 #'   requested dataset (and, where applicable, date/collection).
 #'
 #' @references
 #'   SMIPS: <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/d1995ee8-53f0-4a7d-91c2-ad5e4a23e5e0>
-#'
 #'   ASC: <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/15728dba-b49c-4da5-9073-13d8abe67d7c>
-#'
 #'   AET: <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/9fefa68b-dbed-4c20-88db-a9429fb4ba97>
-#'
 #'   AWC: <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/482301c2-2837-4b0b-bf95-4883a04e5ff7>
-#'
 #'   Soil Beta Diversity: <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/4a428d52-d15c-4bfc-8a67-80697f8c0aa0>
-#'
 #'   Canopy Height: <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/36c98155-c137-44b8-b4e0-6a3e824bbfba>
-#'
 #'   Land Surface Phenology: <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/2bb0c81a-5a09-4a0e-bd86-5cd2be8def26>
 #'
 #' @autoglobal
@@ -216,30 +220,32 @@ read_tern <- function(
     cli::cli_abort("You must provide a {.arg dataset_id}.")
   }
 
-  # Validate dataset ID and collect dots *before* checking the API key so that
-  # input-validation errors surface even when the key is not configured (e.g.
-  # in CI without TERN_API_KEY).
-  did <- .tern_dispatch_id(dataset_id)
+  # Validate dataset ID and specific arguments *before* checking API key
   dots <- list(...)
-
-  # Validate dataset-specific arguments before requiring the API key
+  did <- .tern_dispatch_id(dataset_id)
   .tern_validate_args(did, dots, dataset_id)
-
   api_key <- .check_api_key(api_key %||% get_key())
 
+  # Dispatch to specific dataset helpers
   switch(
     did,
     "d1995ee8" = .read_tern_smips(dots, api_key, max_tries, initial_delay),
     "15728dba" = .read_tern_asc(dots, api_key, max_tries, initial_delay),
     "9fefa68b" = .read_tern_aet(dots, api_key, max_tries, initial_delay),
-    "482301c2" = ,
+    "482301c2" = ,  # Switch fall-through for SLGA datasets
     "slga_cly" = ,
     "slga_snd" = ,
     "slga_slt" = ,
     "slga_bdw" = ,
     "slga_phc" = ,
     "slga_phw" = ,
-    "slga_nto" = .read_tern_slga(did, dots, api_key, max_tries, initial_delay),
+    "slga_nto" = ,
+    "slga_avp" = ,
+    "slga_pto" = ,
+    "slga_cec" = ,
+    "slga_ece" = ,
+    "slga_dul" = ,
+    "slga_l15" = .read_tern_slga(did, dots, api_key, max_tries, initial_delay),
     "4a428d52" = .read_tern_soil_diversity(dots, api_key, max_tries, initial_delay),
     "36c98155" = .read_tern_canopy_height(api_key, max_tries, initial_delay),
     "2bb0c81a" = .read_tern_phenology(dots, api_key, max_tries, initial_delay)
@@ -247,31 +253,33 @@ read_tern <- function(
 }
 
 
-# -- Aliases and metadata tables -----------------------------------------------
-
 #' Alias mapping for short dataset names
 #' Maps user-friendly short names (e.g. "SMIPS", "AWC") to dispatch IDs
 #' @autoglobal
 #' @dev
 .tern_aliases <- list(
-  SMIPS    = "d1995ee8",
-  ASC      = "15728dba",
-  AET      = "9fefa68b",
-  AWC      = "482301c2",
-  CLY      = "slga_cly",
-  SND      = "slga_snd",
-  SLT      = "slga_slt",
-  BDW      = "slga_bdw",
-  PHC      = "slga_phc",
-  PHW      = "slga_phw",
-  NTO      = "slga_nto",
-  SOILDIV  = "4a428d52",
-  CANOPY   = "36c98155",
+  SMIPS = "d1995ee8",
+  ASC = "15728dba",
+  AET = "9fefa68b",
+  AWC = "482301c2",
+  CLY = "slga_cly",
+  SND = "slga_snd",
+  SLT = "slga_slt",
+  BDW = "slga_bdw",
+  PHC = "slga_phc",
+  PHW = "slga_phw",
+  NTO = "slga_nto",
+  AVP = "slga_avp",
+  PTO = "slga_pto",
+  CEC = "slga_cec",
+  ECE = "slga_ece",
+  DUL = "slga_dul",
+  L15 = "slga_l15",
+  SOILDIV = "4a428d52",
+  CANOPY = "36c98155",
   PHENOLOGY = "2bb0c81a"
 )
 
-
-# -- Dispatch helpers ----------------------------------------------------------
 
 #' Normalise a TERN dataset key for switch() dispatch
 #'
@@ -346,6 +354,10 @@ read_tern <- function(
 #' @autoglobal
 #' @dev
 .tern_validate_args <- function(did, dots, dataset_id) {
+  #FIXME: Russell (05/06) as mentioned in Issue #36 discussion, surely
+  #  at some point we move these argument validation bits to their own
+  #  specific dataset file (e.g., SMIPS validation in read_smips.R) to
+  #  improve the SoC.
   switch(
     did,
     # SMIPS (d1995ee8) -- requires date
@@ -380,7 +392,13 @@ read_tern <- function(
     "slga_bdw" = ,
     "slga_phc" = ,
     "slga_phw" = ,
-    "slga_nto" = {
+    "slga_nto" = ,
+    "slga_avp" = ,
+    "slga_pto" = ,
+    "slga_cec" = ,
+    "slga_ece" = ,
+    "slga_dul" = ,
+    "slga_l15" = {
       # SLGA — all static, optional depth/collection with defaults
     },
     "4a428d52" = {

--- a/R/read_tern.R
+++ b/R/read_tern.R
@@ -118,7 +118,10 @@
 #'     \code{"EGS"} (End of Growing Season), \code{"LGS"} (Length of Growing Season),
 #'     \code{"EVI1"} (Minimum EVI before peak), \code{"EVI2"} (Minimum EVI after peak),
 #'     \code{"EVIP"} (EVI at Peak of Growing Season),
-#'     \code{"EVII"} (Integral of EVI under growing season curve).}
+#'     \code{"EVII"} (Integral of EVI under growing season curve),
+#'     \code{"SGS_month"} (Start of Growing Season, monthly resolution),
+#'     \code{"PGS_month"} (Peak of the Growing Season, monthly resolution),
+#'     \code{"EGS_month"} (End of Growing Season, monthly resolution).}
 #' }
 #'
 #' @section Datasets not accessible:

--- a/R/read_tern.R
+++ b/R/read_tern.R
@@ -1,11 +1,12 @@
 #' Read TERN COG Datasets
 #'
 #' A unified interface for reading Cloud Optimised GeoTIFF (\acronym{COG})
-#' data from \acronym{TERN} and related repositories.  Dispatches to a
-#' dataset-specific handler based on \code{dataset_id} and passes any
-#' additional arguments through \code{...}.  The returned object is a
-#' [terra::SpatRaster] that can be plotted, cropped, or extracted with
-#' standard \pkg{terra} or \pkg{tidyterra} workflows.
+#' data from the \acronym{TERN} Data Portal. This function effectively
+#' dispatches to dataset-specific handlers based on the dataset requested
+#' (e.g., SMIPS, SLGA, AET, and so on), and passes any additional arguments
+#' through \code{...}.  The returned object is a [terra::SpatRaster] that
+#' can be plotted, cropped, or extracted with standard \pkg{terra} or
+#' \pkg{tidyterra} workflows.
 #'
 #' @section Dataset aliases:
 #' In addition to full \acronym{TERN} portal keys and 8-character prefixes,
@@ -14,69 +15,69 @@
 #'   \strong{Alias} \tab \strong{Dataset ID} \tab \strong{Description} \cr
 #'   \code{"SMIPS"} \tab \code{TERN/d1995ee8} \tab Daily soil moisture (~1 km) \cr
 #'   \code{"ASC"} \tab \code{TERN/15728dba} \tab Australian Soil Classification (90 m) \cr
-#'   \code{"AET"} \tab \code{TERN/9fefa68b} \tab Monthly evapotranspiration (CMRSET) \cr
+#'   \code{"AET"} \tab \code{TERN/9fefa68b} \tab Monthly evapotranspiration via CMRSET (30 m) \cr
 #'   \code{"AWC"} \tab \code{TERN/482301c2} \tab Available Water Capacity (90 m) \cr
-#'   \code{"CLY"} \tab SLGA \tab Clay content (90 m) \cr
-#'   \code{"SND"} \tab SLGA \tab Sand content (90 m) \cr
-#'   \code{"SLT"} \tab SLGA \tab Silt content (90 m) \cr
-#'   \code{"BDW"} \tab SLGA \tab Bulk density whole earth (90 m) \cr
-#'   \code{"PHC"} \tab SLGA \tab pH CaCl2 (90 m) \cr
-#'   \code{"PHW"} \tab SLGA \tab pH water (90 m) \cr
-#'   \code{"NTO"} \tab SLGA \tab Total Nitrogen (90 m) \cr
-#'   \code{"AVP"} \tab SLGA \tab Available Phosphorus (90 m) \cr
-#'   \code{"PTO"} \tab SLGA \tab Total Phosphorus (90 m) \cr
-#'   \code{"CEC"} \tab SLGA \tab Cation Exchange Capacity (90 m) \cr
-#'   \code{"ECE"} \tab SLGA \tab Effective Cation Exchange Capacity (90 m) \cr
-#'   \code{"DUL"} \tab SLGA \tab Drained Upper Limit water content (90 m) \cr
-#'   \code{"L15"} \tab SLGA \tab 15 Bar Lower Limit water content (90 m) \cr
+#'   \code{"CLY"} \tab \code{TERN/f95dc442} \tab Clay content (90 m) \cr
+#'   \code{"SND"} \tab \code{TERN/4224ddff} \tab Sand content (90 m) \cr
+#'   \code{"SLT"} \tab \code{TERN/11375f04} \tab Silt content (90 m) \cr
+#'   \code{"BDW"} \tab \code{TERN/95978aec} \tab Bulk density whole earth (90 m) \cr
+#'   \code{"PHC"} \tab \code{TERN/258afc98} \tab pH CaCl2 (90 m) \cr
+#'   \code{"PHW"} \tab \code{TERN/c37439a5} \tab pH water (90 m) \cr
+#'   \code{"NTO"} \tab \code{TERN/e9484508} \tab Total Nitrogen (90 m) \cr
+#'   \code{"AVP"} \tab \code{TERN/c6ef289b} \tab Available Phosphorus (90 m) \cr
+#'   \code{"PTO"} \tab \code{TERN/be382e63} \tab Total Phosphorus (90 m) \cr
+#'   \code{"CEC"} \tab \code{TERN/5b4b2991} \tab Cation Exchange Capacity (90 m) \cr
+#'   \code{"ECE"} \tab \code{TERN/0d27cf8b} \tab Effective Cation Exchange Capacity (90 m) \cr
+#'   \code{"DUL"} \tab \code{TERN/de9ddc12} \tab Drained Upper Limit water content (90 m) \cr
+#'   \code{"L15"} \tab \code{TERN/4443f5df} \tab 15 Bar Lower Limit water content (90 m) \cr
 #'   \code{"SOILDIV"} \tab \code{TERN/4a428d52} \tab Soil Beta Diversity (90 m) \cr
 #'   \code{"CANOPY"} \tab \code{TERN/36c98155} \tab Canopy Height (30 m) \cr
 #'   \code{"PHENOLOGY"} \tab \code{TERN/2bb0c81a} \tab Land Surface Phenology (500 m) \cr
 #' }
 #' Convenience wrappers [read_smips()], [read_asc()], [read_aet()],
 #' [read_slga()], [read_soil_diversity()], [read_canopy_height()], and
-#' [read_phenology()] are also provided for direct access to each dataset.
+#' [read_phenology()] are also provided for simplified access to each dataset.
 #'
-#' @section SMIPS — daily soil moisture (\code{"TERN/d1995ee8"}):
+#' @section SMIPS — daily soil moisture (\code{"SMIPS"}):
 #' \describe{
-#'   \item{\code{date}}{Required.  A single day to query, _e.g._
+#'   \item{\code{date}}{Required. A single day to query, _e.g._
 #'     \code{"2024-01-15"} or \code{as.Date("2024-01-15")}.  Both
-#'     \code{Character} and \code{Date} classes are accepted.}
+#'     \code{character} and \code{Date} classes are accepted.}
 #'   \item{\code{collection}}{One of \code{"totalbucket"} (default),
 #'     \code{"SMindex"}, \code{"bucket1"}, \code{"bucket2"},
 #'     \code{"deepD"}, or \code{"runoff"}.}
 #' }
-#' Data availability: 2015-01-01 to approximately 7 days before today.
+#' Data availability: from 2005-01-01 to today. (Updated regularly.)
 #'
-#' @section ASC -- Australian Soil Classification (\code{"TERN/15728dba"}):
+#' @section ASC -- Australian Soil Classification (\code{"ASC"}):
 #' \describe{
 #'   \item{\code{collection}}{One of \code{"EV"} (estimated soil order
-#'     class, default) or \code{"CI"} (confusion index -- a measure of
-#'     mapping uncertainty).  No \code{date} argument required; this is a
-#'     static product.}
+#'     class, default) or \code{"CI"} (confusion index -- a measure of the
+#'     classification uncertainty).}
 #' }
 #'
-#' @section AET -- Actual Evapotranspiration/CMRSET (\code{"TERN/9fefa68b"}):
+#' @section AET -- Actual Evapotranspiration/CMRSET (\code{"AET"}):
 #' \describe{
-#'   \item{\code{date}}{Required.  A month to query, _e.g._
+#'   \item{\code{date}}{Required. A month to query, _e.g._
 #'     \code{"2023-06-01"} or \code{as.Date("2023-06-01")}.  Both
-#'     \code{Character} and \code{Date} classes are accepted.  The value is
-#'     snapped to the first of the month internally.}
+#'     \code{character} and \code{Date} classes are accepted.  The value is
+#'     snapped to the first of the month.}
 #'   \item{\code{collection}}{One of \code{"ETa"} (primary AET band in
-#'     mm/month, default) or \code{"pixel_qa"} (quality assurance flags).}
+#'     mm/month, default) or \code{"pixel_qa"} (quality assurance attributes).}
 #' }
-#' Data availability: 1987-05-01 onwards.
+#' Data availability: 1987-05-01 onward, monthly.
 #'
 #' @section SLGA soil attributes (\code{"AWC"}, \code{"CLY"}, etc.):
 #' 14 \acronym{SLGA} (Soil and Landscape Grid of Australia) soil
 #' attributes are available as static 90 m products, each with six standard
-#' depth layers and two statistics:
+#' depth layers and three statistics:
 #' \describe{
 #'   \item{\code{depth}}{One of \code{"000_005"} (default), \code{"005_015"},
 #'     \code{"015_030"}, \code{"030_060"}, \code{"060_100"}, or
 #'     \code{"100_200"} (cm).}
-#'   \item{\code{collection}}{One of \code{"EV"} (estimated value, default)
-#'     or \code{"CI"} (confidence interval).}
+#'   \item{\code{collection}}{One of \code{"EV"} (estimated value, default),
+#'     \code{"05"} (lower percentile limit for the 95% confidence interval)
+#'     or \code{"95"} (upper percentile limit for the confidence interval).}
 #' }
 #' Supported attributes (use as the \code{dataset_id} alias):
 #' \describe{
@@ -95,25 +96,22 @@
 #'   \item{\code{"DUL"}}{Drained Upper Limit volumetric water content (percent)}
 #'   \item{\code{"L15"}}{15 Bar Lower Limit volumetric water content (percent)}
 #' }
-#' Convenience wrapper: [read_slga()].
 #'
-#' @section Soil Beta Diversity (\code{"SOILDIV"}, \code{TERN/4a428d52}):
+#' @section Soil Beta Diversity (\code{"SOILDIV"}):
 #' \describe{
 #'   \item{\code{collection}}{One of \code{"Bacteria"} (default) or
 #'     \code{"Fungi"}.}
-#'   \item{\code{axis}}{NMDS axis number: \code{1} (default), \code{2}, or
+#'   \item{\code{axis}}{NMDS axis: \code{1} (default), \code{2}, or
 #'     \code{3}.}
 #' }
-#' Static 90 m product.  Convenience wrapper: [read_soil_diversity()].
 #'
-#' @section Canopy Height (\code{"CANOPY"}, \code{TERN/36c98155}):
-#' Single static 30 m best-pick composite from the OzTreeMap project.
-#' No additional arguments required.
-#' Convenience wrapper: [read_canopy_height()].
+#' @section Canopy Height (\code{"CANOPY"}):
+#' Single static 30 m X 30 m best-pick canopy height model composite,
+#' from the OzTreeMap project. No function arguments required.
 #'
-#' @section Land Surface Phenology (\code{"PHENOLOGY"}, \code{TERN/2bb0c81a}):
+#' @section Land Surface Phenology (\code{"PHENOLOGY"}):
 #' \describe{
-#'   \item{\code{year}}{Required.  An integer year (2003--2018).}
+#'   \item{\code{year}}{Required. An integer year (2003--2018).}
 #'   \item{\code{season}}{Season number: \code{1} (default) or \code{2}.}
 #'   \item{\code{collection}}{Phenology metric — one of \code{"SGS"}
 #'     (Start of Growing Season, default), \code{"PGS"} (Peak of Growing Season),
@@ -122,7 +120,6 @@
 #'     \code{"EVIP"} (EVI at Peak of Growing Season),
 #'     \code{"EVII"} (Integral of EVI under growing season curve).}
 #' }
-#' 500 m resolution.  Convenience wrapper: [read_phenology()].
 #'
 #' @section Datasets not accessible:
 #' The following datasets are tracked in the \acronym{TERN} catalogue but
@@ -145,17 +142,19 @@
 #' @param ... Dataset-specific arguments — \code{date}, \code{collection},
 #'   etc.  See the relevant section above for each dataset.
 #' @param api_key A \code{character} string containing your \acronym{TERN}
-#'   \acronym{API} key.  Defaults to automatic detection from your
-#'   \code{.Renviron} or \code{.Rprofile}.  See \code{\link{get_key}} for
-#'   setup instructions.
+#'   \acronym{API} key. Defaults to automatic detection from your
+#'   \code{.Renviron} or \code{.Rprofile}.  See [get_key()] for setup.
 #' @param max_tries Maximum number of download retries before an error is
-#'   raised.  When \code{NULL} (default), resolved from
-#'   \code{getOption("nert.max_tries", 3L)}.  Pass an integer to override
-#'   for a single call.
+#'   raised. Default=\code{NULL}, in which case the maximum retry number is
+#'   resolved from the option \code{nert.max_tries} if that option exists.
+#'   (Defaults to 3 retries if \code{nert.max_tries} has not been set.)
 #' @param initial_delay Initial retry delay in seconds (doubles with each
-#'   attempt).  When \code{NULL} (default), resolved from
-#'   \code{getOption("nert.initial_delay", 1L)}.  Pass an integer to
-#'   override for a single call.
+#'   attempt). Default=\code{NULL}, in which case the initial delay is
+#'   resolved from the option \code{nert.initial_delay} if that option exists.
+#'   (Defaults to a 1 second initial delay if \code{nert.initial_delay} has
+#'   not been set.)
+#'
+#' @returns A [terra::SpatRaster] object for the requested dataset.
 #'
 #' @section Package options:
 #' \pkg{nert} reads two package-level options on every call.  Both are
@@ -179,33 +178,173 @@
 #' r_asc <- read_tern("ASC")
 #' autoplot(r_asc)
 #'
-#' # SLGA soil attributes — depth and collection
+#' # SLGA soil attributes
 #' r_clay <- read_tern("CLY", depth = "000_005")
-#' r_awc  <- read_tern("AWC", depth = "015_030", collection = "CI")
+#' r_awc_upper  <- read_tern("AWC", depth = "015_030", collection = "95")
+#' r_awc_lower  <- read_tern("AWC", depth = "015_030", collection = "05")
 #'
 #' # Soil Beta Diversity
 #' r_bact <- read_tern("SOILDIV", collection = "Bacteria", axis = 1)
 #'
-#' # Canopy Height (single static product)
+#' # Canopy Height
 #' r_ch <- read_tern("CANOPY")
 #'
 #' # Land Surface Phenology
 #' r_phen <- read_tern("PHENOLOGY", year = 2018, collection = "SGS")
 #'
-#' # Full TERN keys still work
+#' # Full TERN dataset IDs also work
 #' r2 <- read_tern("TERN/d1995ee8", date = "2024-01-15")
 #'
-#' @returns A [terra::SpatRaster] object of the national mosaic for the
-#'   requested dataset (and, where applicable, date/collection).
-#'
 #' @references
-#'   SMIPS: <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/d1995ee8-53f0-4a7d-91c2-ad5e4a23e5e0>
-#'   ASC: <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/15728dba-b49c-4da5-9073-13d8abe67d7c>
-#'   AET: <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/9fefa68b-dbed-4c20-88db-a9429fb4ba97>
-#'   AWC: <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/482301c2-2837-4b0b-bf95-4883a04e5ff7>
-#'   Soil Beta Diversity: <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/4a428d52-d15c-4bfc-8a67-80697f8c0aa0>
-#'   Canopy Height: <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/36c98155-c137-44b8-b4e0-6a3e824bbfba>
-#'   Land Surface Phenology: <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/2bb0c81a-5a09-4a0e-bd86-5cd2be8def26>
+#' \describe{
+#'   \item{**SMIPS: Daily volumetric soil moisture**}{
+#'     Stenson, M., Searle, R., Malone, B., Sommer, A., Renzullo, L. & Di, H.
+#'     (2021): Australia wide daily volumetric soil moisture estimates.
+#'     Version 1.0. Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25901/b020-nm39}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/d1995ee8-53f0-4a7d-91c2-ad5e4a23e5e0>
+#'   }
+#'   \item{**ASC: Australian Soil Classification Map**}{
+#'     Searle, R. (2021). Australian Soil Classification Map. Version 1.
+#'     Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25901/edyr-wg85}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/15728dba-b49c-4da5-9073-13d8abe67d7c>
+#'   }
+#'   \item{**AET: Actual Evapotranspiration using the CMRSET algorithm**}{
+#'     McVicar, T., Vleeshouwer, J., Van Niel, T., Guerschman, J. &
+#'     Peña-Arancibia, J. (2022). Actual Evapotranspiration for Australia
+#'     using CMRSET algorithm. Version 1.0. Terrestrial Ecosystem Research
+#'     Network. (Dataset). \doi{10.25901/gg27-ck96}.\cr\cr
+#'     TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/9fefa68b-dbed-4c20-88db-a9429fb4ba97>
+#'   }
+#'   \item{**AWC: SLGA Attribute - Available Volumetric Water Capacity**}{
+#'     Searle, R., Nimalka Somarathna, P. & Malone, B. (2023). Soil and
+#'     Landscape Grid National Soil Attribute Maps - Available Volumetric
+#'     Water Capacity (Percent) (3 arc second resolution) Version 2.
+#'     Version 2.0. Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/4jwj-na34}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/482301c2-b9a1-4345-b142-815f9b37890a>
+#'   }
+#'   \item{**CLY: SLGA Attribute - Clay content**}{
+#'     Malone, B. & Searle, R. (2022). Soil and Landscape Grid National
+#'     Soil Attribute Maps - Clay (3" resolution) - Release 2. Version 2.
+#'     Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/hc4s-3130}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/f95dc442-013b-4fad-b31f-91ba86fbe7f5>
+#'   }
+#'   \item{**SND: SLGA Attribute - Sand content**}{
+#'     Malone, B. & Searle, R. (2022). Soil and Landscape Grid National Soil
+#'     Attribute Maps - Sand (3" resolution) - Release 2. Version 2.0.
+#'     Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/rjmy-pa10}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/4224ddff-5fb4-4170-b5ea-c0c500599700>
+#'   }
+#'   \item{**SLT: SLGA Attribute - Silt content**}{
+#'     Malone, B. & Searle, R. (2022). Soil and Landscape Grid National Soil
+#'     Attribute Maps - Silt (3" resolution) - Release 2. Version 2.0.
+#'     Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/2ew1-0w57}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/11375f04-b5cd-46a7-bcac-0e83fcb58605>
+#'   }
+#'   \item{**BDW: SLGA Attribute - Bulk Density (Whole Earth)**}{
+#'     Malone, B. (2023). Soil and Landscape Grid National Soil Attribute
+#'     Maps - Bulk Density - Whole Earth - Release 2. Version 2.
+#'     Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/gxyn-pd07}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/95978aec-6ba8-446b-a721-2b875d9f61a8>
+#'   }
+#'   \item{**PHC: SLGA Attribute - pH (of 1:5 soil/0.01M CaCl2 extract)**}{
+#'     Malone, B. & Searle, R. (2024). Soil and Landscape Grid National Soil
+#'     Attribute Maps - pH - Calcium Chloride (3" resolution) - Release 2.
+#'     Version 2. Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/7320-hw30}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/258afc98-7407-4781-b241-cb0293b4b8aa>
+#'   }
+#'   \item{**PHW: SLGA Attribute - pH (of 1:5 soil water solution)**}{
+#'     Malone, B. (2022). Soil and Landscape Grid National Soil Attribute
+#'     Maps - pH (Water) (3" resolution) - Release 1. Version 1.0.
+#'     Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/37z2-0q10}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/c37439a5-e622-44ab-9c24-bfd632d8203c>
+#'   }
+#'   \item{**NTO: SLGA Attribute - Total nitrogen**}{
+#'     Malone, B. & Searle, R. (2024). Soil and Landscape Grid National Soil
+#'     Attribute Maps - Total Nitrogen (3" resolution) - Release 2. Version 2.
+#'     Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/pm2n-ww12}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/e9484508-c705-4c23-9195-f26d64b9d4f1>
+#'   }
+#'   \item{**AVP: SLGA Attribute - Available phosphorus**}{
+#'     Zund, P. (2022). Soil and Landscape Grid National Soil Attribute Maps
+#'     - Available Phosphorus (3" resolution) - Release 1. Version 1.0.
+#'     Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/6qzh-b979}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/c6ef289b-1ca8-4e53-b8b4-aa97e4706c63>
+#'   }
+#'   \item{**PTO: SLGA Attribute - Total phosphorus**}{
+#'     Malone, B. & Searle, R. (2024). Soil and Landscape Grid National Soil
+#'     Attribute Maps - Total Phosphorus (3" resolution) - Release 2.
+#'     Version 2. Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/7j78-md43}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/be382e63-5ff6-40a9-930f-c84655a5bd87>
+#'   }
+#'   \item{**CEC: SLGA Attribute - Cation exchange capacity**}{
+#'     Malone, B. (2024). Soil and Landscape Grid National Soil Attribute Maps
+#'     - Cation Exchange Capacity (3" resolution) - Release 1. Version 1.0.
+#'     Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/pkva-gf85}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/5b4b2991-bfa6-41df-be33-7009a5d0a5b0>
+#'   }
+#'   \item{**ECE: SLGA Attribute - Effective cation exchange capacity**}{
+#'     Viscarra Rossel, R., Chen, C., Grundy, M., Searle, R., Clifford, D.,
+#'     Odgers, N., Holmes, K., Griffin, T., Liddicoat, C. & Kidd, D. (2014).
+#'     Soil and Landscape Grid National Soil Attribute Maps - Effective Cation
+#'     Exchange Capacity (3" resolution) - Release 1. Version 1. Terrestrial
+#'     Ecosystem Research Network. (Dataset).
+#'     \doi{10.4225/08/546F091C11777}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/0d27cf8b-6627-4f33-8398-1b525bc1a210>
+#'   }
+#'   \item{**DUL: SLGA Attribute - Drained upper limit volumetric water content**}{
+#'     Searle, R. & Nimalka Somarathna, P. (2022). Soil and Landscape Grid
+#'     National Soil Attribute Maps - Drained Upper Limit Volumetric Water
+#'     Content (Percent) (3 arc second resolution) Version 1. Version 1.0.
+#'     Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/jnvd-3a26}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/de9ddc12-b8e4-4ff2-99c4-390227a848aa>
+#'   }
+#'   \item{**L15: SLGA Attribute - 15 bar lower limit volumetric water content**}{
+#'     Searle, R. & Nimalka Somarathna, P. (2022). Soil and Landscape Grid
+#'     National Soil Attribute Maps - 15 Bar Lower Limit Volumetric Water
+#'     Content (Percent) (3 arc second resolution) Version 1. Version 1.0.
+#'     Terrestrial Ecosystem Research Network. (Dataset).
+#'     \doi{10.25919/awp8-nv68}.\cr\cr TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/4443f5df-a0b2-4352-b44b-83f7feb1e27d>
+#'   }
+#'   \item{**SOILDIV: Soil Bacteria and Soil Fungi Beta Diversity**}{
+#'     Dobarco, M., Wadoux, A. & Xue, P. (2024). Soil and Landscape Grid National
+#'     Soil Attribute Maps - Soil Bacteria and Fungi Beta Diversity (3"
+#'     resolution) - Release 1. Version 1.0. Terrestrial Ecosystem Research
+#'     Network. (Dataset). \doi{10.25919/4x7n-y874}.\cr\cr
+#'     TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/4a428d52-dda6-4097-8dd9-d3ec63973029>
+#'   }
+#'   \item{**CANOPY: OzTreeMap Best-Pick Canopy Height Model**}{
+#'     Pucino, N., McVicar, T., Levick, S. & Albert van Dijk (2025).
+#'     Australia-Wide 30 m Machine Learning-Derived Canopy Height Models
+#'     Composites: Best Pick and Median. Version 1. Terrestrial Ecosystem
+#'     Research Network. (Dataset). \doi{10.25901/xqv7-jk46}.\cr\cr
+#'     TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/36c98155-39c8-4eec-9070-a978933f3fa3>
+#'   }
+#'   \item{**PHENOLOGY: Australian Land Surface Phenology**}{
+#'     Xie, Q. & Huete, A. (2024). Australian land surface phenology dataset at
+#'     500m resolution. Version 1.0. Terrestrial Ecosystem Research Network.
+#'     (Dataset). URL: <https://portal.tern.org.au/metadata/2bb0c81a-41a9-434c-b87a-db0301cb52fb>.\cr\cr
+#'     TERN Point-of-truth metadata URL:
+#'     <https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/2bb0c81a-41a9-434c-b87a-db0301cb52fb>
+#'   }
+#' }
 #'
 #' @autoglobal
 #' @export
@@ -232,20 +371,20 @@ read_tern <- function(
     "d1995ee8" = .read_tern_smips(dots, api_key, max_tries, initial_delay),
     "15728dba" = .read_tern_asc(dots, api_key, max_tries, initial_delay),
     "9fefa68b" = .read_tern_aet(dots, api_key, max_tries, initial_delay),
-    "482301c2" = ,  # Switch fall-through for SLGA datasets
-    "slga_cly" = ,
-    "slga_snd" = ,
-    "slga_slt" = ,
-    "slga_bdw" = ,
-    "slga_phc" = ,
-    "slga_phw" = ,
-    "slga_nto" = ,
-    "slga_avp" = ,
-    "slga_pto" = ,
-    "slga_cec" = ,
-    "slga_ece" = ,
-    "slga_dul" = ,
-    "slga_l15" = .read_tern_slga(did, dots, api_key, max_tries, initial_delay),
+    "482301c2" = ,  # AWC -- Switch fall-through for SLGA datasets
+    "f95dc442" = ,  # CLY
+    "4224ddff" = ,  # SND
+    "11375f04" = ,  # SLT
+    "95978aec" = ,  # BDW
+    "258afc98" = ,  # PHC
+    "c37439a5" = ,  # PHW
+    "e9484508" = ,  # NTO
+    "c6ef289b" = ,  # AVP
+    "be382e63" = ,  # PTO
+    "5b4b2991" = ,  # CEC
+    "0d27cf8b" = ,  # ECE
+    "de9ddc12" = ,  # DUL
+    "4443f5df" = .read_tern_slga(did, dots, api_key, max_tries, initial_delay),  # L15
     "4a428d52" = .read_tern_soil_diversity(dots, api_key, max_tries, initial_delay),
     "36c98155" = .read_tern_canopy_height(api_key, max_tries, initial_delay),
     "2bb0c81a" = .read_tern_phenology(dots, api_key, max_tries, initial_delay)
@@ -254,6 +393,7 @@ read_tern <- function(
 
 
 #' Alias mapping for short dataset names
+#'
 #' Maps user-friendly short names (e.g. "SMIPS", "AWC") to dispatch IDs
 #' @autoglobal
 #' @dev
@@ -262,19 +402,19 @@ read_tern <- function(
   ASC = "15728dba",
   AET = "9fefa68b",
   AWC = "482301c2",
-  CLY = "slga_cly",
-  SND = "slga_snd",
-  SLT = "slga_slt",
-  BDW = "slga_bdw",
-  PHC = "slga_phc",
-  PHW = "slga_phw",
-  NTO = "slga_nto",
-  AVP = "slga_avp",
-  PTO = "slga_pto",
-  CEC = "slga_cec",
-  ECE = "slga_ece",
-  DUL = "slga_dul",
-  L15 = "slga_l15",
+  CLY = "f95dc442",
+  SND = "4224ddff",
+  SLT = "11375f04",
+  BDW = "95978aec",
+  PHC = "258afc98",
+  PHW = "c37439a5",
+  NTO = "e9484508",
+  AVP = "c6ef289b",
+  PTO = "be382e63",
+  CEC = "5b4b2991",
+  ECE = "0d27cf8b",
+  DUL = "de9ddc12",
+  L15 = "4443f5df",
   SOILDIV = "4a428d52",
   CANOPY = "36c98155",
   PHENOLOGY = "2bb0c81a"
@@ -357,12 +497,17 @@ read_tern <- function(
   #FIXME: Russell (05/06) as mentioned in Issue #36 discussion, surely
   #  at some point we move these argument validation bits to their own
   #  specific dataset file (e.g., SMIPS validation in read_smips.R) to
-  #  improve the SoC.
+  #  improve the SoC. As it is, a lot of this validation ends up
+  #  duplicated in the respective read_* functions too.
   switch(
     did,
-    # SMIPS (d1995ee8) -- requires date
+    # SMIPS (d1995ee8) -- requires date, must be >= 2015-01-01
     "d1995ee8" = {
-      date <- if (!is.null(dots[["date"]])) dots[["date"]] else dots[["day"]]
+      date <- if (!is.null(dots[["date"]])) {
+        dots[["date"]]
+      } else {
+        dots[["day"]]
+      }
       if (is.null(date)) {
         cli::cli_abort(
           "SMIPS requires a {.arg date} argument (daily resolution),
@@ -370,11 +515,13 @@ read_tern <- function(
         )
       }
     },
+
     # ASC (15728dba) -- no required arguments
     "15728dba" = {
       # Collection defaults to "EV"; no validation needed
     },
-    # AET (9fefa68b) -- requires date, must be >= 2000-02-01
+
+    # AET (9fefa68b) -- requires date, must be >= 1987-05-01
     "9fefa68b" = {
       date <- if (!is.null(dots[["date"]])) dots[["date"]] else dots[["month"]]
       if (is.null(date)) {
@@ -385,28 +532,34 @@ read_tern <- function(
       }
       .check_aet_date(date)
     },
-    "482301c2" = ,
-    "slga_cly" = ,
-    "slga_snd" = ,
-    "slga_slt" = ,
-    "slga_bdw" = ,
-    "slga_phc" = ,
-    "slga_phw" = ,
-    "slga_nto" = ,
-    "slga_avp" = ,
-    "slga_pto" = ,
-    "slga_cec" = ,
-    "slga_ece" = ,
-    "slga_dul" = ,
-    "slga_l15" = {
-      # SLGA — all static, optional depth/collection with defaults
+
+    # SLGA datasets -- no required arguments
+    "482301c2" = ,  # AWC
+    "f95dc442" = ,  # CLY
+    "4224ddff" = ,  # SND
+    "11375f04" = ,  # SLT
+    "95978aec" = ,  # BDW
+    "258afc98" = ,  # PHC
+    "c37439a5" = ,  # PHW
+    "e9484508" = ,  # NTO
+    "c6ef289b" = ,  # AVP
+    "be382e63" = ,  # PTO
+    "5b4b2991" = ,  # CEC
+    "0d27cf8b" = ,  # ECE
+    "de9ddc12" = ,  # DUL
+    "4443f5df" = {  # L15
+      # Defaults to "EV" collection at "000_005" cm depth.
     },
+
+    # Soil Beta Diversity -- optional collection/axis with defaults
     "4a428d52" = {
-      # Soil Beta Diversity — optional collection/axis with defaults
+      # Defaults to Bacteria, NMDS axis 1
     },
-    "36c98155" = {
-      # Canopy Height — no arguments required
-    },
+
+    # Best-pick canopy height -- no required arguments.
+    "36c98155" = {  },
+
+    # Phenology -- requires year. The season and collection are optional.
     "2bb0c81a" = {
       year <- dots[["year"]]
       if (is.null(year)) {
@@ -434,6 +587,8 @@ read_tern <- function(
         )
       }
     },
+
+    # Fail-safe
     .tern_not_implemented(dataset_id)
   )
   invisible(NULL)

--- a/R/utils-dates.R
+++ b/R/utils-dates.R
@@ -7,7 +7,7 @@
 #' @note This was taken from \CRANpkg{nasapower}.
 #' @examples
 #' .check_date("2024-01-01")
-#' @author Adam H. Sparks \email{adamhsparks@@curtin.edu.au}
+#' @author Adam H. Sparks \email{adamhsparks@curtin.edu.au}
 #' @autoglobal
 #' @dev
 .check_date <- function(x) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,6 +17,7 @@ knitr::opts_chunk$set(
 # nert
 
 <!-- badges: start -->
+[![Project Status: Active](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![R-CMD-check](https://github.com/AAGI-AUS/nert/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/AAGI-AUS/nert/actions/workflows/R-CMD-check.yaml)
 [![codecov](https://codecov.io/gh/AAGI-AUS/nert/graph/badge.svg?token=WgBeTrqQnQ)](https://app.codecov.io/gh/AAGI-AUS/nert)
 <!-- badges: end -->

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ output: github_document
 # nert
 
 <!-- badges: start -->
+[![Project Status: Active](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![R-CMD-check](https://github.com/AAGI-AUS/nert/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/AAGI-AUS/nert/actions/workflows/R-CMD-check.yaml)
 [![codecov](https://codecov.io/gh/AAGI-AUS/nert/graph/badge.svg?token=WgBeTrqQnQ)](https://app.codecov.io/gh/AAGI-AUS/nert)
 <!-- badges: end -->

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,13 +8,13 @@
   "codeRepository": "https://github.com/AAGI-AUS/nert",
   "issueTracker": "https://github.com/AAGI-AUS/nert/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
     "url": "https://r-project.org"
   },
-  "runtimePlatform": "R version 4.5.1 (2025-06-13)",
+  "runtimePlatform": "R version 4.5.2 (2025-10-31)",
   "author": [
     {
       "@type": "Person",
@@ -47,14 +47,11 @@
       "@type": "Person",
       "givenName": "Max",
       "familyName": "Moldovan",
-      "email": "max.moldovan@adelaide.edu.au"
+      "email": "max.moldovan@adelaide.edu.au",
+      "@id": "https://orcid.org/0000-0001-9680-8474"
     }
   ],
   "copyrightHolder": [
-    {
-      "@type": "Organization",
-      "name": "Curtin University"
-    },
     {
       "@type": "Organization",
       "name": "Grains Research and Development Corporation"
@@ -102,6 +99,18 @@
     },
     {
       "@type": "SoftwareApplication",
+      "identifier": "nlme",
+      "name": "nlme",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=nlme"
+    },
+    {
+      "@type": "SoftwareApplication",
       "identifier": "rmarkdown",
       "name": "rmarkdown",
       "provider": {
@@ -128,7 +137,7 @@
       "@type": "SoftwareApplication",
       "identifier": "testthat",
       "name": "testthat",
-      "version": ">= 3.0.0",
+      "version": ">= 3.2.0",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
@@ -148,6 +157,18 @@
         "url": "https://cran.r-project.org"
       },
       "sameAs": "https://CRAN.R-project.org/package=usethis"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "withr",
+      "name": "withr",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=withr"
     }
   ],
   "softwareRequirements": {
@@ -208,18 +229,6 @@
     },
     "6": {
       "@type": "SoftwareApplication",
-      "identifier": "nlme",
-      "name": "nlme",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=nlme"
-    },
-    "7": {
-      "@type": "SoftwareApplication",
       "identifier": "rlang",
       "name": "rlang",
       "provider": {
@@ -230,7 +239,7 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=rlang"
     },
-    "8": {
+    "7": {
       "@type": "SoftwareApplication",
       "identifier": "terra",
       "name": "terra",
@@ -242,7 +251,7 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=terra"
     },
-    "9": {
+    "8": {
       "@type": "SoftwareApplication",
       "identifier": "tidyterra",
       "name": "tidyterra",
@@ -254,7 +263,7 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=tidyterra"
     },
-    "10": {
+    "9": {
       "@type": "SoftwareApplication",
       "identifier": "utils",
       "name": "utils"
@@ -264,8 +273,44 @@
   "applicationCategory": "Tools",
   "isPartOf": "https://grdc.com.au/research/partnerships-and-initiatives/strategic-partnerships/aagi",
   "keywords": ["TERN", "soil-data", "Australia", "earth-science", "data-access"],
-  "fileSize": "1178.007KB",
-  "releaseNotes": "https://github.com/AAGI-AUS/nert/blob/master/NEWS.md",
+  "fileSize": "1444.548KB",
+  "citation": [
+    {
+      "@type": "SoftwareSourceCode",
+      "datePublished": "2026",
+      "author": [
+        {
+          "@type": "Person",
+          "givenName": "Adam H.",
+          "familyName": "Sparks"
+        },
+        {
+          "@type": "Person",
+          "givenName": "Wasin",
+          "familyName": "Pipattungsakul"
+        },
+        {
+          "@type": "Person",
+          "givenName": "Russell",
+          "familyName": "Edson"
+        },
+        {
+          "@type": "Person",
+          "givenName": "Sam",
+          "familyName": "Rogers"
+        },
+        {
+          "@type": "Person",
+          "givenName": "Max",
+          "familyName": "Moldovan"
+        }
+      ],
+      "name": "{nert}: An API Client for TERN Data",
+      "url": "https://aagi-aus.github.io/nert/",
+      "description": "R package version 1.1.0"
+    }
+  ],
+  "releaseNotes": "https://github.com/AAGI-AUS/nert/blob/main/NEWS.md",
   "readme": "https://github.com/AAGI-AUS/nert/blob/main/README.md",
-  "contIntegration": ["https://github.com/AAGI-AUS/nert/actions/workflows/R-CMD-check.yaml", "https://codecov.io/gh/AAGI-AUS/nert"]
+  "contIntegration": ["https://github.com/AAGI-AUS/nert/actions/workflows/R-CMD-check.yaml", "https://app.codecov.io/gh/AAGI-AUS/nert"]
 }

--- a/man/collect_tern_data.Rd
+++ b/man/collect_tern_data.Rd
@@ -35,9 +35,9 @@ coordinate columns named \code{lon}/\code{lat} or \code{x}/\code{y}.  Takes prec
 over \code{lon}/\code{lat} when supplied.}
 
 \item{datasets}{\code{character} vector of dataset aliases to collect.
-Default: all 14 datasets (SMIPS, ASC, AET, AWC, CLY, SND, SLT, BDW,
-PHC, PHW, NTO, SOILDIV, CANOPY, PHENOLOGY).  Use \code{NULL} or \code{"all"}
-for all datasets.}
+Default: all 20 datasets (SMIPS, ASC, AET, AWC, CLY, SND, SLT, BDW,
+PHC, PHW, NTO, AVP, PTO, CEC, ECE, DUL, L15, SOILDIV, CANOPY, PHENOLOGY).
+Use \code{NULL} or \code{"all"} for all datasets.}
 
 \item{depth}{For SLGA datasets: depth interval (default \code{"all"}).
 Options: \code{"000_005"}, \code{"005_015"}, \code{"015_030"}, \code{"030_060"},

--- a/man/dot-build_work_items.Rd
+++ b/man/dot-build_work_items.Rd
@@ -13,7 +13,7 @@
 
 \item{depth}{SLGA depth selector.}
 
-\item{stat}{SLGA stat selector (\code{"EV"} or \code{"CI"}).}
+\item{stat}{SLGA stat selector (\code{"EV"}, \code{"05"} or \code{"95"}).}
 
 \item{smips_collection}{SMIPS collection selector.}
 }

--- a/man/dot-check_aet_date.Rd
+++ b/man/dot-check_aet_date.Rd
@@ -16,6 +16,6 @@ month.
 \description{
 Validates and snaps a user-supplied date value to the first of the month,
 then checks it against the \acronym{AET} data availability window
-(from 2000-02-01 onwards).
+(from 1987-05-01 onwards).
 }
 \keyword{internal}

--- a/man/dot-check_collection_agreement.Rd
+++ b/man/dot-check_collection_agreement.Rd
@@ -14,9 +14,12 @@
 \description{
 SMIPS daily COGs are published from 2015-01-01 (the earliest archived
 complete set of soil moisture GeoTIFFs available on the TERN Data Portal),
-up to approximately seven days before today.  Requests outside that
-window will return HTTP 404 from the GDAL vsicurl driver, resulting in a
-"file does not exist" error from \code{\link[terra:rast]{terra::rast()}}.  This helper function
-catches this case before any network I/O.
+up to today. Requests outside that window will definitely return HTTP 404
+from the GDAL vsicurl driver, resulting in a "file does not exist" error
+from \code{\link[terra:rast]{terra::rast()}}.  This helper function catches this case before
+any network I/O. (Note: the requested rasters may still be unavailable
+even if this check passes, e.g., if the user has requested a very recent
+raster that has not been added to the TERN server yet. This validation
+function simply checks for the obviously impossible cases.)
 }
 \keyword{internal}

--- a/man/dot-check_collection_agreement.Rd
+++ b/man/dot-check_collection_agreement.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/read_smips.R
 \name{.check_collection_agreement}
 \alias{.check_collection_agreement}
-\title{Validate Days Requested Align With Collection}
+\title{Validate date requested aligns with SMIPS collection extent}
 \usage{
 .check_collection_agreement(.collection, .day)
 }
@@ -12,10 +12,11 @@
 \item{.day}{The user-supplied date being asked for.}
 }
 \description{
-SMIPS daily COGs are published from 2015-11-20 (the earliest archived
-national mosaic on the TERN portal) up to approximately seven days before
-today.  Requests outside that window return HTTP 404 from the GDAL vsicurl
-driver, which surfaces as an opaque "file does not exist" error from
-\code{\link[terra:rast]{terra::rast()}}.  This helper catches that case before any network I/O.
+SMIPS daily COGs are published from 2015-01-01 (the earliest archived
+complete set of soil moisture GeoTIFFs available on the TERN Data Portal),
+up to approximately seven days before today.  Requests outside that
+window will return HTTP 404 from the GDAL vsicurl driver, resulting in a
+"file does not exist" error from \code{\link[terra:rast]{terra::rast()}}.  This helper function
+catches this case before any network I/O.
 }
 \keyword{internal}

--- a/man/dot-fill_work_item.Rd
+++ b/man/dot-fill_work_item.Rd
@@ -19,9 +19,6 @@
 
 \item{api_key}{TERN API key.}
 }
-\value{
-\code{invisible(NULL)}.
-}
 \description{
 For a time-series work item, exactly one row block (\code{length(coords)}
 rows) is filled.  For a static work item, the value is replicated

--- a/man/dot-make_aet_url.Rd
+++ b/man/dot-make_aet_url.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/read_aet.R
 \name{.make_aet_url}
 \alias{.make_aet_url}
-\title{Build a GDAL vsicurl URL for an AET Collection}
+\title{Build a GDAL vsicurl URL to retrieve AET data}
 \usage{
 .make_aet_url(.collection, .month, .api_key)
 }
@@ -19,6 +19,6 @@ the month.}
 A \code{character} GDAL vsicurl URL string.
 }
 \description{
-Build a GDAL vsicurl URL for an AET Collection
+Build a GDAL vsicurl URL to retrieve AET data
 }
 \keyword{internal}

--- a/man/dot-make_smips_url.Rd
+++ b/man/dot-make_smips_url.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/read_smips.R
 \name{.make_smips_url}
 \alias{.make_smips_url}
-\title{Create an SMIPS URL}
+\title{Create a SMIPS URL}
 \usage{
 .make_smips_url(.collection, .day)
 }

--- a/man/dot-read_tern_aet.Rd
+++ b/man/dot-read_tern_aet.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/read_aet.R
 \name{.read_tern_aet}
 \alias{.read_tern_aet}
-\title{Internal handler for AET/CMRSET (\code{TERN/9fefa68b})}
+\title{Internal handler for retrieving the AET data}
 \usage{
 .read_tern_aet(dots, api_key, max_tries, initial_delay)
 }
@@ -14,6 +14,6 @@
 \item{max_tries, initial_delay}{Passed to \code{\link[=.read_cog]{.read_cog()}}.}
 }
 \description{
-Internal handler for AET/CMRSET (\code{TERN/9fefa68b})
+Internal handler for retrieving the AET data
 }
 \keyword{internal}

--- a/man/dot-read_tern_asc.Rd
+++ b/man/dot-read_tern_asc.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/read_asc.R
 \name{.read_tern_asc}
 \alias{.read_tern_asc}
-\title{Internal handler for ASC (\code{TERN/15728dba})}
+\title{Internal handler for retrieving ASC rasters}
 \usage{
 .read_tern_asc(dots, api_key, max_tries, initial_delay)
 }
@@ -14,6 +14,6 @@
 \item{max_tries, initial_delay}{Passed to \code{\link[=.read_cog]{.read_cog()}}.}
 }
 \description{
-Internal handler for ASC (\code{TERN/15728dba})
+Internal handler for retrieving ASC rasters
 }
 \keyword{internal}

--- a/man/dot-read_tern_canopy_height.Rd
+++ b/man/dot-read_tern_canopy_height.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/read_canopy_height.R
 \name{.read_tern_canopy_height}
 \alias{.read_tern_canopy_height}
-\title{Internal handler for Canopy Height (\code{TERN/36c98155})}
+\title{Internal handler for retrieving Canopy Height data}
 \usage{
 .read_tern_canopy_height(api_key, max_tries, initial_delay)
 }
@@ -12,6 +12,6 @@
 \item{max_tries, initial_delay}{Passed to \code{\link[=.read_cog]{.read_cog()}}.}
 }
 \description{
-Internal handler for Canopy Height (\code{TERN/36c98155})
+Internal handler for retrieving Canopy Height data
 }
 \keyword{internal}

--- a/man/dot-read_tern_slga.Rd
+++ b/man/dot-read_tern_slga.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/read_slga.R
 \name{.read_tern_slga}
 \alias{.read_tern_slga}
-\title{Internal handler for SLGA soil attributes}
+\title{Internal handler for retrieving SLGA soil attributes}
 \usage{
 .read_tern_slga(did, dots, api_key, max_tries, initial_delay)
 }

--- a/man/dot-read_tern_smips.Rd
+++ b/man/dot-read_tern_smips.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/read_smips.R
 \name{.read_tern_smips}
 \alias{.read_tern_smips}
-\title{Internal handler for SMIPS (\code{TERN/d1995ee8})}
+\title{Internal handler for retrieving SMIPS datasets}
 \usage{
 .read_tern_smips(dots, api_key, max_tries, initial_delay)
 }
@@ -14,6 +14,6 @@
 \item{max_tries, initial_delay}{Passed to \code{\link[=.read_cog]{.read_cog()}}.}
 }
 \description{
-Internal handler for SMIPS (\code{TERN/d1995ee8})
+Internal handler for retrieving SMIPS datasets
 }
 \keyword{internal}

--- a/man/dot-read_tern_soil_diversity.Rd
+++ b/man/dot-read_tern_soil_diversity.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/read_soil_diversity.R
 \name{.read_tern_soil_diversity}
 \alias{.read_tern_soil_diversity}
-\title{Internal handler for Soil Beta Diversity (\code{TERN/4a428d52})}
+\title{Internal handler for retrieving Soil Beta Diversity datasets}
 \usage{
 .read_tern_soil_diversity(dots, api_key, max_tries, initial_delay)
 }
@@ -14,6 +14,6 @@
 \item{max_tries, initial_delay}{Passed to \code{\link[=.read_cog]{.read_cog()}}.}
 }
 \description{
-Internal handler for Soil Beta Diversity (\code{TERN/4a428d52})
+Internal handler for retrieving Soil Beta Diversity datasets
 }
 \keyword{internal}

--- a/man/dot-tern_aliases.Rd
+++ b/man/dot-tern_aliases.Rd
@@ -3,8 +3,7 @@
 \docType{data}
 \name{.tern_aliases}
 \alias{.tern_aliases}
-\title{Alias mapping for short dataset names
-Maps user-friendly short names (e.g. "SMIPS", "AWC") to dispatch IDs}
+\title{Alias mapping for short dataset names}
 \format{
 An object of class \code{list} of length 20.
 }
@@ -12,7 +11,6 @@ An object of class \code{list} of length 20.
 .tern_aliases
 }
 \description{
-Alias mapping for short dataset names
 Maps user-friendly short names (e.g. "SMIPS", "AWC") to dispatch IDs
 }
 \keyword{datasets}

--- a/man/dot-tern_aliases.Rd
+++ b/man/dot-tern_aliases.Rd
@@ -6,7 +6,7 @@
 \title{Alias mapping for short dataset names
 Maps user-friendly short names (e.g. "SMIPS", "AWC") to dispatch IDs}
 \format{
-An object of class \code{list} of length 14.
+An object of class \code{list} of length 20.
 }
 \usage{
 .tern_aliases

--- a/man/nert-package.Rd
+++ b/man/nert-package.Rd
@@ -30,8 +30,7 @@ Authors:
 
 Other contributors:
 \itemize{
-  \item Curtin University (\href{https://ror.org/02n415q13}{ROR}) (Provided support through Adam Sparks's time.) [copyright holder]
-  \item Grains Research and Development Corporation (\href{https://ror.org/02xwr1996}{ROR}) (GRDC Project CUR2210-005OPX (AAGI-CU)) [funder, copyright holder]
+  \item Grains Research and Development Corporation (\href{https://ror.org/02xwr1996}{ROR}) (GRDC Project CUR2210-005OPX (AAGI-CU), UOA2301-005OPX (AAGI-AU)) [funder, copyright holder]
 }
 
 }

--- a/man/read_aet.Rd
+++ b/man/read_aet.Rd
@@ -41,7 +41,7 @@ A \code{\link[terra:rast]{terra::rast()}} object of the requested ET collection.
 Wrapper around \code{\link[=read_tern]{read_tern()}} for retrieving the CMRSET actual
 evapotranspiration data (v2.2) from the TERN Data Portal. This dataset
 provides monthly estimates of actual ET (mm/month) at 30 m resolution
-from February 2000 onwards.
+from February 2000 onwards. #FIXME: May 1987 actually.
 }
 \examples{
 \dontshow{if (interactive()) withAutoprint(\{ # examplesIf}

--- a/man/read_aet.Rd
+++ b/man/read_aet.Rd
@@ -18,30 +18,34 @@ read_aet(
 is snapped to the first of the month internally.  Required.}
 
 \item{collection}{One of \code{"ETa"} (actual evapotranspiration in
-mm/month, default) or \code{"pixel_qa"} (quality assurance flags).}
+mm/month, default) or \code{"pixel_qa"} (quality assurance attributes).}
 
 \item{api_key}{A \code{character} string containing your \acronym{TERN}
-\acronym{API} key.  Defaults to automatic detection from your
+\acronym{API} key. Defaults to automatic detection from your
 \code{.Renviron} or \code{.Rprofile}.  See \code{\link[=get_key]{get_key()}} for setup.}
 
 \item{max_tries}{Maximum number of download retries before an error is
-raised.  When \code{NULL} (default), resolved from
-\code{getOption("nert.max_tries", 3L)}.  Pass an integer to override
-for a single call.}
+raised. Default=\code{NULL}, in which case the maximum retry number is
+resolved from the option \code{nert.max_tries} if that option exists.
+(Defaults to 3 retries if \code{nert.max_tries} has not been set.)}
 
 \item{initial_delay}{Initial retry delay in seconds (doubles with each
-attempt).  When \code{NULL} (default), resolved from
-\code{getOption("nert.initial_delay", 1L)}.  Pass an integer to
-override for a single call.}
+attempt). Default=\code{NULL}, in which case the initial delay is
+resolved from the option \code{nert.initial_delay} if that option exists.
+(Defaults to a 1 second initial delay if \code{nert.initial_delay} has
+not been set.)}
 }
 \value{
-A \code{\link[terra:rast]{terra::rast()}} object of the requested ET collection.
+A \link[terra:SpatRaster-class]{terra::SpatRaster} object of the requested Evapotranspiration collection.
 }
 \description{
 Wrapper around \code{\link[=read_tern]{read_tern()}} for retrieving the CMRSET actual
 evapotranspiration data (v2.2) from the TERN Data Portal. This dataset
 provides monthly estimates of actual ET (mm/month) at 30 m resolution
-from February 2000 onwards. #FIXME: May 1987 actually.
+from May 1987 onwards, using the CSIRO MODIS Reflectance-based Scaling
+EvapoTranspiration (CMRSET) algorithm that combines potential
+evapotranspiration data from the Bureau of Meteorology together with
+satellite image data provided by MODIS, VIIRS, Landsat and Sentinel-2.
 }
 \examples{
 \dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
@@ -63,11 +67,14 @@ r_recent <- read_aet(Sys.Date())
 \dontshow{\}) # examplesIf}
 }
 \references{
-CMRSET portal:
-\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/9fefa68b-dbed-4c20-88db-a9429fb4ba97}
+McVicar, T., Vleeshouwer, J., Van Niel, T., Guerschman, J. &
+Peña-Arancibia, J. (2022). Actual Evapotranspiration for Australia
+using CMRSET algorithm. Version 1.0. Terrestrial Ecosystem Research
+Network. (Dataset). \doi{10.25901/gg27-ck96}.
 
-CMRSET DOI: \doi{10.25901/gg27-ck96}
+TERM CMRSET Actual Evapotranspiration Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/9fefa68b-dbed-4c20-88db-a9429fb4ba97}
 }
 \seealso{
-\code{\link[=read_tern]{read_tern()}}, \code{\link[=read_smips]{read_smips()}}, \code{\link[=read_asc]{read_asc()}}
+\code{\link[=read_tern]{read_tern()}}
 }

--- a/man/read_aet.Rd
+++ b/man/read_aet.Rd
@@ -38,8 +38,9 @@ override for a single call.}
 A \code{\link[terra:rast]{terra::rast()}} object of the requested ET collection.
 }
 \description{
-Wrapper around \code{\link[=read_tern]{read_tern()}} for TERN/CMRSET evapotranspiration data.
-Provides monthly estimates of actual ET (mm/month) at 30 m resolution
+Wrapper around \code{\link[=read_tern]{read_tern()}} for retrieving the CMRSET actual
+evapotranspiration data (v2.2) from the TERN Data Portal. This dataset
+provides monthly estimates of actual ET (mm/month) at 30 m resolution
 from February 2000 onwards.
 }
 \examples{

--- a/man/read_aet.Rd
+++ b/man/read_aet.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/read_aet.R
 \name{read_aet}
 \alias{read_aet}
-\title{Read CMRSET Actual Evapotranspiration Data}
+\title{Read CMRSET Actual Evapotranspiration Data from TERN}
 \usage{
 read_aet(
   date,

--- a/man/read_aet.Rd
+++ b/man/read_aet.Rd
@@ -59,8 +59,8 @@ r_jan <- read_aet("2023-01-01")
 # Quality assurance flags for June 2023
 r_qa <- read_aet("2023-06-01", collection = "pixel_qa")
 
-# ET from February 2000 (earliest available)
-r_early <- read_aet("2000-02-01")
+# ET from May 1987 (earliest available)
+r_early <- read_aet("1987-05-01")
 
 # Current/recent ET (within last month)
 r_recent <- read_aet(Sys.Date())

--- a/man/read_asc.Rd
+++ b/man/read_asc.Rd
@@ -78,7 +78,6 @@ autoplot(r_ci)
 }
 \seealso{
 Other COGs: 
-\code{\link{read_canopy_height}()},
 \code{\link{read_tern}()}
 }
 \concept{COGs}

--- a/man/read_asc.Rd
+++ b/man/read_asc.Rd
@@ -81,7 +81,6 @@ Other COGs:
 \code{\link{read_canopy_height}()},
 \code{\link{read_phenology}()},
 \code{\link{read_slga}()},
-\code{\link{read_soil_diversity}()},
 \code{\link{read_tern}()}
 }
 \concept{COGs}

--- a/man/read_asc.Rd
+++ b/man/read_asc.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/read_asc.R
 \name{read_asc}
 \alias{read_asc}
-\title{Read Australian Soil Classification (ASC) Data}
+\title{Read Australian Soil Classification (ASC) Data from TERN}
 \source{
 ASC mosaic metadata (estimated soil-order class and confusion index):
 \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/15728dba-b49c-4da5-9073-13d8abe67d7c}.
@@ -79,7 +79,6 @@ autoplot(r_ci)
 \seealso{
 Other COGs: 
 \code{\link{read_canopy_height}()},
-\code{\link{read_phenology}()},
 \code{\link{read_tern}()}
 }
 \concept{COGs}

--- a/man/read_asc.Rd
+++ b/man/read_asc.Rd
@@ -3,81 +3,76 @@
 \name{read_asc}
 \alias{read_asc}
 \title{Read Australian Soil Classification (ASC) Data from TERN}
-\source{
-ASC mosaic metadata (estimated soil-order class and confusion index):
-\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/15728dba-b49c-4da5-9073-13d8abe67d7c}.
-The underlying COG endpoints (\code{ASC_EV_C_P_AU_TRN_N.cog.tif} and
-\code{ASC_CI_C_P_AU_TRN_N.cog.tif} under
-\code{/model-derived/slga/NationalMaps/SoilClassifications/ASC/90m/} on
-\code{data.tern.org.au}) require an authenticated request and are
-constructed internally by this package.
-}
 \usage{
 read_asc(
-  confusion_index = FALSE,
+  collection = "EV",
   api_key = get_key(),
   max_tries = NULL,
   initial_delay = NULL
 )
 }
 \arguments{
-\item{confusion_index}{A \code{logical} value. If \code{FALSE} (default), returns
-estimated \acronym{ASC} soil order classes (character). If \code{TRUE}, returns
-the Confusion Index (numeric, 0-100) indicating mapping reliability.}
+\item{collection}{The ASC dataset collection variant (default \code{"EV"}). Options:
+\describe{
+\item{\code{"EV"}}{\strong{(Estimated) Soil Order Class} (character). The
+estimated ASC soil order class. Each pixel of the raster maps to one
+of 14 soil order classes: Vertosol, Sodosol, Dermosol, Chromosol,
+Ferrosol, Kurosol, Tenosol, Kandosol, Hydrosol, Podosol, Rudosol,
+Calcarasol, Organosol, Anthroposol.}
+\item{\code{"CI"}}{\strong{Confusion Index} (0-1). A unitless index between
+0.0 and 1.0, approximating the uncertainty of the Random Forest
+classification for the soil order at each pixel. (A higher value of the
+confusion index means that the classification at that pixel is more
+uncertain.)}
+}}
 
-\item{api_key}{A \code{character} string containing your \acronym{API} key,
-a random string provided to you by \acronym{TERN}, for the request.
-Defaults to automatically detecting your key from your local .Renviron,
-.Rprofile or similar.  Alternatively, you may directly provide your key as
-a string here or use functionality like that from \CRANpkg{keyring}.  If
-nothing is provided, you will be prompted on how to set up your \R session
-so that it is auto-detected and a browser window will open at the
-\acronym{TERN} website for you to request a key.}
+\item{api_key}{A \code{character} string containing your \acronym{TERN}
+\acronym{API} key. Defaults to automatic detection from your
+\code{.Renviron} or \code{.Rprofile}.  See \code{\link[=get_key]{get_key()}} for setup.}
 
 \item{max_tries}{Maximum number of download retries before an error is
-raised.  When \code{NULL} (default), resolved from
-\code{getOption("nert.max_tries", 3L)}.  Pass an integer to override for
-a single call.}
+raised. Default=\code{NULL}, in which case the maximum retry number is
+resolved from the option \code{nert.max_tries} if that option exists.
+(Defaults to 3 retries if \code{nert.max_tries} has not been set.)}
 
 \item{initial_delay}{Initial retry delay in seconds (doubles with each
-attempt).  When \code{NULL} (default), resolved from
-\code{getOption("nert.initial_delay", 1L)}.  Pass an integer to override
-for a single call.}
+attempt). Default=\code{NULL}, in which case the initial delay is
+resolved from the option \code{nert.initial_delay} if that option exists.
+(Defaults to a 1 second initial delay if \code{nert.initial_delay} has
+not been set.)}
 }
 \value{
-A  \code{\link[terra:rast]{terra::rast()}} object.
+A \link[terra:SpatRaster-class]{terra::SpatRaster} object containing the soil order classes (or the
+values of the confusion index).
 }
 \description{
-Wrapper around \code{\link[=read_tern]{read_tern()}} for Australian Soil Classification (\acronym{ASC})
-soil order classes at 90 m resolution. Returns character soil order descriptions
-(e.g., "2 - Sodosol") with optional mapping reliability (confusion index).
-}
-\details{
-The ASC dataset provides soil order classifications based on the Australian
-Soil Classification system. Each pixel contains the predicted soil order and
-associated reliability/uncertainty estimates.
-
-\strong{Output data type:} Character (soil order names and codes)
-
-\strong{Reliability:} Confusion Index indicates mapping uncertainty (lower = more reliable)
+Wrapper around \code{\link[=read_tern]{read_tern()}} for retrieving Australian Soil Classification
+(\acronym{ASC}) soil order classes from the TERN Data Portal. The ASC dataset
+provides a comprehensive map at 90m X 90m spatial resolution across
+Australia, mapping each spatial pixel to one of 14 soil order classes using
+a Random Forest classifier. The dataset also provides a confusion index
+raster that estimates the uncertainty (between 0.0 and 1.0) associated with
+the classification.
 }
 \examples{
 \dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
-
 # Australian Soil Classification (soil orders as character)
 r_asc <- read_asc()
 autoplot(r_asc)
 
-# Confusion Index (mapping reliability, lower = more reliable)
-r_ci <- read_asc(confusion_index = TRUE)
+# Confusion Index (uncertainty of the classification, higher=more uncertain)
+r_ci <- read_asc(collection = "CI")
 autoplot(r_ci)
 \dontshow{\}) # examplesIf}
 }
 \references{
+Searle, R. (2021). Australian Soil Classification Map. Version 1.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25901/edyr-wg85}.
+
+TERN ASC Point-of-truth metadata URL:
 \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/15728dba-b49c-4da5-9073-13d8abe67d7c}
 }
 \seealso{
-Other COGs: 
-\code{\link{read_tern}()}
+\code{\link[=read_tern]{read_tern()}}
 }
-\concept{COGs}

--- a/man/read_asc.Rd
+++ b/man/read_asc.Rd
@@ -80,7 +80,6 @@ autoplot(r_ci)
 Other COGs: 
 \code{\link{read_canopy_height}()},
 \code{\link{read_phenology}()},
-\code{\link{read_slga}()},
 \code{\link{read_tern}()}
 }
 \concept{COGs}

--- a/man/read_canopy_height.Rd
+++ b/man/read_canopy_height.Rd
@@ -50,7 +50,6 @@ autoplot(r)
 Other COGs: 
 \code{\link{read_asc}()},
 \code{\link{read_phenology}()},
-\code{\link{read_slga}()},
 \code{\link{read_tern}()}
 }
 \concept{COGs}

--- a/man/read_canopy_height.Rd
+++ b/man/read_canopy_height.Rd
@@ -51,7 +51,6 @@ Other COGs:
 \code{\link{read_asc}()},
 \code{\link{read_phenology}()},
 \code{\link{read_slga}()},
-\code{\link{read_soil_diversity}()},
 \code{\link{read_tern}()}
 }
 \concept{COGs}

--- a/man/read_canopy_height.Rd
+++ b/man/read_canopy_height.Rd
@@ -8,34 +8,31 @@ read_canopy_height(api_key = get_key(), max_tries = NULL, initial_delay = NULL)
 }
 \arguments{
 \item{api_key}{A \code{character} string containing your \acronym{TERN}
-\acronym{API} key.  Defaults to automatic detection via \code{\link[=get_key]{get_key()}}.}
+\acronym{API} key. Defaults to automatic detection from your
+\code{.Renviron} or \code{.Rprofile}.  See \code{\link[=get_key]{get_key()}} for setup.}
 
 \item{max_tries}{Maximum number of download retries before an error is
-raised.  When \code{NULL} (default), resolved from
-\code{getOption("nert.max_tries", 3L)}.  Pass an integer to override
-for a single call.}
+raised. Default=\code{NULL}, in which case the maximum retry number is
+resolved from the option \code{nert.max_tries} if that option exists.
+(Defaults to 3 retries if \code{nert.max_tries} has not been set.)}
 
 \item{initial_delay}{Initial retry delay in seconds (doubles with each
-attempt).  When \code{NULL} (default), resolved from
-\code{getOption("nert.initial_delay", 1L)}.  Pass an integer to
-override for a single call.}
+attempt). Default=\code{NULL}, in which case the initial delay is
+resolved from the option \code{nert.initial_delay} if that option exists.
+(Defaults to a 1 second initial delay if \code{nert.initial_delay} has
+not been set.)}
 }
 \value{
-A \code{\link[terra:rast]{terra::rast()}} object of the national OzTreeMap canopy height
-composite.
+A \link[terra:SpatRaster-class]{terra::SpatRaster} object of the requested vegetation canopy height.
+Note that the raster returned by this function uses the Australian Albers
+(EPSG:3577) coordinate reference system, not WGS84 (EPSG:4326).
 }
 \description{
-Read the OzTreeMap Canopy Height composite Cloud Optimised GeoTIFF
-(\acronym{COG}) from \acronym{TERN}.  This product provides a nationwide
-canopy height map at 30 m resolution derived from Landsat imagery.
-}
-\details{
-This is a single static product --- no date or collection arguments are
-required.
-
-This is a convenience wrapper around
-\code{read_tern("CANOPY")}; see \code{\link[=read_tern]{read_tern()}} for full details and
-additional datasets.
+Wrapper around \code{\link[=read_tern]{read_tern()}} for retrieving the OzTreeMap Best-Pick
+Canopy Height model dataset from the TERN Data Portal. The model estimates
+the vegetation canopy height (in metres) at 30m X 30m spatial resolution
+across Australia, based on underlying ML-derived vegetation models
+tuned to variable time periods between 2007 and 2020.
 }
 \examples{
 \dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
@@ -44,11 +41,14 @@ autoplot(r)
 \dontshow{\}) # examplesIf}
 }
 \references{
-\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/36c98155-c137-44b8-b4e0-6a3e824bbfba}
+Pucino, N., McVicar, T., Levick, S. & Albert van Dijk (2025).
+Australia-Wide 30 m Machine Learning-Derived Canopy Height Models
+Composites: Best Pick and Median. Version 1. Terrestrial Ecosystem
+Research Network. (Dataset). \doi{10.25901/xqv7-jk46}.
+
+TERN Canopy Height model Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/36c98155-39c8-4eec-9070-a978933f3fa3}
 }
 \seealso{
-Other COGs: 
-\code{\link{read_asc}()},
-\code{\link{read_tern}()}
+\code{\link[=read_tern]{read_tern()}}
 }
-\concept{COGs}

--- a/man/read_canopy_height.Rd
+++ b/man/read_canopy_height.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/read_canopy_height.R
 \name{read_canopy_height}
 \alias{read_canopy_height}
-\title{Read Canopy Height from TERN}
+\title{Read OzTreeMap Canopy Height Data from TERN}
 \usage{
 read_canopy_height(api_key = get_key(), max_tries = NULL, initial_delay = NULL)
 }
@@ -49,7 +49,6 @@ autoplot(r)
 \seealso{
 Other COGs: 
 \code{\link{read_asc}()},
-\code{\link{read_phenology}()},
 \code{\link{read_tern}()}
 }
 \concept{COGs}

--- a/man/read_phenology.Rd
+++ b/man/read_phenology.Rd
@@ -90,7 +90,6 @@ r_rog <- read_phenology(year = 2010, collection = "ROG")
 Other COGs: 
 \code{\link{read_asc}()},
 \code{\link{read_canopy_height}()},
-\code{\link{read_slga}()},
 \code{\link{read_tern}()}
 }
 \concept{COGs}

--- a/man/read_phenology.Rd
+++ b/man/read_phenology.Rd
@@ -91,7 +91,6 @@ Other COGs:
 \code{\link{read_asc}()},
 \code{\link{read_canopy_height}()},
 \code{\link{read_slga}()},
-\code{\link{read_soil_diversity}()},
 \code{\link{read_tern}()}
 }
 \concept{COGs}

--- a/man/read_phenology.Rd
+++ b/man/read_phenology.Rd
@@ -20,7 +20,8 @@ read_phenology(
 
 \item{collection}{Phenology metric abbreviation.  One of \code{"SGS"}
 (default), \code{"PGS"}, \code{"EGS"}, \code{"LGS"}, \code{"EVI1"},
-\code{"EVI2"}, \code{"EVIP"}, or \code{"EVII"}.}
+\code{"EVI2"}, \code{"EVIP"}, \code{"EVII"}, \code{"SGS_month"},
+\code{"PGS_month"} or \code{"EGS_month"}.}
 
 \item{api_key}{A \code{character} string containing your \acronym{TERN}
 \acronym{API} key. Defaults to automatic detection from your
@@ -50,7 +51,7 @@ imagery.
 }
 \section{Phenology metrics}{
 
-Eight phenological metrics are available via the \code{collection}
+Eleven phenological metrics are available via the \code{collection}
 argument:
 \describe{
 \item{\code{"SGS"}}{\strong{Start of Growing Season} (default). A number
@@ -77,6 +78,18 @@ season.}
 \item{\code{"EVII"}}{\strong{Integral of the EVI across the season}. The
 calculated integral of the Enhanced Vegetation Index (including the
 factor of 10000 scaling) under the growing season cycle curve.}
+\item{\code{"SGS_month"}}{\strong{Start of the growing season by month}.
+A number between 1 and 12, indicating the month for the start of the
+growing season (i.e., the \code{"SGS"} metric but reprocessed to
+monthly time resolution).}
+\item{\code{"PGS_month"}}{\strong{Peak of the growing season by month}.
+A number between 1 and 12, indicating the month for the peak of the
+growing season (i.e., the \code{"PGS"} metric but reprocessed to
+monthly time resolution).}
+\item{\code{"EGS_month"}}{\strong{End of the growing season by month}.
+A number between 1 and 12, indicating the month for the end of the
+growing season (i.e., the \code{"EGS"} metric but reprocessed to
+monthly time resolution).}
 }
 }
 

--- a/man/read_phenology.Rd
+++ b/man/read_phenology.Rd
@@ -19,54 +19,65 @@ read_phenology(
 \item{season}{Season number: \code{1} (default) or \code{2}.}
 
 \item{collection}{Phenology metric abbreviation.  One of \code{"SGS"}
-(default), \code{"PGS"}, \code{"EGS"}, \code{"LGS"}, \code{"SOS"},
-\code{"POS"}, \code{"EOS"}, \code{"LOS"}, \code{"ROG"}, or
-\code{"ROS"}.}
+(default), \code{"PGS"}, \code{"EGS"}, \code{"LGS"}, \code{"EVI1"},
+\code{"EVI2"}, \code{"EVIP"}, or \code{"EVII"}.}
 
 \item{api_key}{A \code{character} string containing your \acronym{TERN}
-\acronym{API} key.  Defaults to automatic detection via \code{\link[=get_key]{get_key()}}.}
+\acronym{API} key. Defaults to automatic detection from your
+\code{.Renviron} or \code{.Rprofile}.  See \code{\link[=get_key]{get_key()}} for setup.}
 
 \item{max_tries}{Maximum number of download retries before an error is
-raised.  When \code{NULL} (default), resolved from
-\code{getOption("nert.max_tries", 3L)}.  Pass an integer to override
-for a single call.}
+raised. Default=\code{NULL}, in which case the maximum retry number is
+resolved from the option \code{nert.max_tries} if that option exists.
+(Defaults to 3 retries if \code{nert.max_tries} has not been set.)}
 
 \item{initial_delay}{Initial retry delay in seconds (doubles with each
-attempt).  When \code{NULL} (default), resolved from
-\code{getOption("nert.initial_delay", 1L)}.  Pass an integer to
-override for a single call.}
+attempt). Default=\code{NULL}, in which case the initial delay is
+resolved from the option \code{nert.initial_delay} if that option exists.
+(Defaults to a 1 second initial delay if \code{nert.initial_delay} has
+not been set.)}
 }
 \value{
-A \code{\link[terra:rast]{terra::rast()}} object of the national phenology mosaic for
-the requested year, season, and metric.
+A \link[terra:SpatRaster-class]{terra::SpatRaster} object of the requested phenology metric.
 }
 \description{
-Read Australian Land Surface Phenology Cloud Optimised GeoTIFF
-(\acronym{COG}) files from \acronym{TERN}.  This product provides
-phenological metrics derived from MODIS MYD13A1 imagery at 500 m
-resolution.  Data are available for years 2003--2018, with up to two
-growing seasons per year.
+Wrapper around \code{\link[=read_tern]{read_tern()}} for retrieving the Australian land surface
+phenology dataset (v1.0) from the TERN Data Portal. This data comprises
+phenology metrics from two growing seasons per year between 2003 and
+2018 (inclusive), estimated at 500m X 500m spatial resolution across
+all of Australia using thresholded MODIS Enhanced Vegetation Index (EVI)
+imagery.
 }
 \section{Phenology metrics}{
 
-Ten phenological metrics are available (use as the \code{collection}
-argument):
+Eight phenological metrics are available via the \code{collection}
+argument:
 \describe{
-\item{\code{"SGS"}}{Start of Growing Season (default).}
-\item{\code{"PGS"}}{Peak of Growing Season.}
-\item{\code{"EGS"}}{End of Growing Season.}
-\item{\code{"LGS"}}{Length of Growing Season.}
-\item{\code{"SOS"}}{Start of Season.}
-\item{\code{"POS"}}{Peak of Season.}
-\item{\code{"EOS"}}{End of Season.}
-\item{\code{"LOS"}}{Length of Season.}
-\item{\code{"ROG"}}{Rate of Greening.}
-\item{\code{"ROS"}}{Rate of Senescence.}
+\item{\code{"SGS"}}{\strong{Start of Growing Season} (default). A number
+between -150 and 345 indicating the start of the growing season (with
+negative numbers meaning the prior year).}
+\item{\code{"PGS"}}{\strong{Peak of Growing Season}. A number between 9 and
+361 indicating the day of the year for the peak of the growing season.}
+\item{\code{"EGS"}}{\strong{End of Growing Season}. A number between 25 and
+519 indicating the day of the year that marks the end of the growing
+season, with numbers above 365 (or 366 for leap years) meaning the
+following year.}
+\item{\code{"LGS"}}{\strong{Length of Growing Season}, measured in days.}
+\item{\code{"EVI1"}}{\strong{Minimum of EVI before peak}. A unitless index
+between 0 and 10000 (i.e., scaled by 10000) for the minimum
+value of the Enhanced Vegetation Index \emph{before} the peak of the growing
+season.}
+\item{\code{"EVI2"}}{\strong{Minimum of EVI after peak}. A unitless index
+between 0 and 10000 (i.e., scaled by 10000) for the minimum
+value of the Enhanced Vegetation Index \emph{after} the peak of the growing
+season.}
+\item{\code{"EVIP"}}{\strong{Peak EVI}. A unitless index between 0 and 10000
+(i.e., scaled by 10000) for the value of the Enhanced Vegetation Index
+\emph{at} the peak of the growing season.}
+\item{\code{"EVII"}}{\strong{Integral of the EVI across the season}. The
+calculated integral of the Enhanced Vegetation Index (including the
+factor of 10000 scaling) under the growing season cycle curve.}
 }
-
-This is a convenience wrapper around
-\code{read_tern("PHENOLOGY", ...)}; see \code{\link[=read_tern]{read_tern()}} for full
-details and additional datasets.
 }
 
 \examples{
@@ -78,18 +89,16 @@ autoplot(r)
 # Read End of Growing Season for 2015, Season 2
 r_egs <- read_phenology(year = 2015, season = 2, collection = "EGS")
 autoplot(r_egs)
-
-# Rate of Greening
-r_rog <- read_phenology(year = 2010, collection = "ROG")
 \dontshow{\}) # examplesIf}
 }
 \references{
+Xie, Q. & Huete, A. (2024). Australian land surface phenology dataset at
+500m resolution. Version 1.0. Terrestrial Ecosystem Research Network.
+(Dataset). URL: \url{https://portal.tern.org.au/metadata/2bb0c81a-41a9-434c-b87a-db0301cb52fb}.
+
+TERN Land Surface Phenology Point-of-truth metadata URL:
 \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/2bb0c81a-5a09-4a0e-bd86-5cd2be8def26}
 }
 \seealso{
-Other COGs: 
-\code{\link{read_asc}()},
-\code{\link{read_canopy_height}()},
-\code{\link{read_tern}()}
+\code{\link[=read_tern]{read_tern()}}
 }
-\concept{COGs}

--- a/man/read_phenology.Rd
+++ b/man/read_phenology.Rd
@@ -97,7 +97,7 @@ Xie, Q. & Huete, A. (2024). Australian land surface phenology dataset at
 (Dataset). URL: \url{https://portal.tern.org.au/metadata/2bb0c81a-41a9-434c-b87a-db0301cb52fb}.
 
 TERN Land Surface Phenology Point-of-truth metadata URL:
-\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/2bb0c81a-5a09-4a0e-bd86-5cd2be8def26}
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/2bb0c81a-41a9-434c-b87a-db0301cb52fb}
 }
 \seealso{
 \code{\link[=read_tern]{read_tern()}}

--- a/man/read_slga.Rd
+++ b/man/read_slga.Rd
@@ -23,8 +23,9 @@ read_slga(
 \code{"015_030"}, \code{"030_060"}, \code{"060_100"}, or
 \code{"100_200"}.}
 
-\item{collection}{One of \code{"EV"} (estimated value, default) or
-\code{"CI"} (confidence interval).}
+\item{collection}{One of \code{"EV"} (estimated value, default),
+\code{"05"} (lower percentile limit for the 95\% confidence interval) or
+\code{"95"} (upper percentile limit for the confidence interval).}
 
 \item{api_key}{A \code{character} string containing your \acronym{TERN}
 \acronym{API} key. Defaults to automatic detection from your
@@ -49,8 +50,8 @@ Wrapper around \code{\link[=read_tern]{read_tern()}} for retrieving various Soil
 Grid of Australia (SLGA) datasets from the TERN Data Portal. 14 soil
 attributes are available at 90m X 90m spatial resolution across Australia,
 each with six standard depth layers (0-5cm, 5-15cm, 15-30cm, 30-60cm,
-60-100cm, 100-200cm) and two statistics (estimated value, confidence
-interval).
+60-100cm, 100-200cm) and three statistics (estimated value, and the lower
+(05) and upper (95) percentile limits for the confidence interval).
 }
 \section{Supported soil attributes}{
 
@@ -82,7 +83,8 @@ autoplot(r)
 r_awc <- read_slga("AWC", depth = "015_030")
 
 # Read pH (CaCl2) confidence interval at 30-60 cm
-r_phc <- read_slga("PHC", depth = "030_060", collection = "CI")
+r_phc_low <- read_slga("PHC", depth = "030_060", collection = "05")
+r_phc_up <- read_slga("PHC", depth = "030_060", collection = "95")
 \dontshow{\}) # examplesIf}
 }
 \references{

--- a/man/read_slga.Rd
+++ b/man/read_slga.Rd
@@ -103,7 +103,6 @@ Other COGs:
 \code{\link{read_asc}()},
 \code{\link{read_canopy_height}()},
 \code{\link{read_phenology}()},
-\code{\link{read_soil_diversity}()},
 \code{\link{read_tern}()}
 }
 \concept{COGs}

--- a/man/read_slga.Rd
+++ b/man/read_slga.Rd
@@ -15,8 +15,9 @@ read_slga(
 }
 \arguments{
 \item{attribute}{One of \code{"AWC"}, \code{"CLY"}, \code{"SND"},
-\code{"SLT"}, \code{"BDW"}, \code{"PHC"}, \code{"PHW"}, or
-\code{"NTO"}.}
+\code{"SLT"}, \code{"BDW"}, \code{"PHC"}, \code{"PHW"}, \code{"NTO"},
+\code{"AVP"}, \code{"PTO"}, \code{"CEC"}, \code{"ECE"}, \code{"DUL"}, or
+\code{"L15"}.}
 
 \item{depth}{One of \code{"000_005"} (default), \code{"005_015"},
 \code{"015_030"}, \code{"030_060"}, \code{"060_100"}, or
@@ -45,7 +46,7 @@ A \link[terra:SpatRaster-class]{terra::SpatRaster} object of the requested SLGA 
 }
 \description{
 Wrapper around \code{\link[=read_tern]{read_tern()}} for retrieving various Soil and Landscape
-Grid of Australia (SLGA) datasets from the TERN Data Portal. Eight soil
+Grid of Australia (SLGA) datasets from the TERN Data Portal. 14 soil
 attributes are available at 90m X 90m spatial resolution across Australia,
 each with six standard depth layers (0-5cm, 5-15cm, 15-30cm, 30-60cm,
 60-100cm, 100-200cm) and two statistics (estimated value, confidence
@@ -62,12 +63,18 @@ interval).
 \item{\code{"PHC"}}{pH (of 1:5 soil/0.01M CaCl2 extract)}
 \item{\code{"PHW"}}{pH (of 1:5 soil water solution)}
 \item{\code{"NTO"}}{Total Nitrogen (\%)}
+\item{\code{"AVP"}}{Available soil Phosphorus (mg/kg)}
+\item{\code{"PTO"}}{Total soil Phosphorus (\%)}
+\item{\code{"CEC"}}{Cation Exchange Capacity (meq/100g)}
+\item{\code{"ECE"}}{Effective Cation Exchange Capacity (meq/100g)}
+\item{\code{"DUL"}}{Drained Upper Limit volumetric water content (\%)}
+\item{\code{"L15"}}{15 Bar Lower Limit volumetric water content (\%)}
 }
 }
 
 \examples{
 \dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
-# Read clay content at 0-5 cm depth
+# Read clay content at 0-5 cm depth (default depth)
 r <- read_slga("CLY")
 autoplot(r)
 
@@ -136,6 +143,52 @@ Attribute Maps - Total Nitrogen (3" resolution) - Release 2. Version 2.
 Terrestrial Ecosystem Research Network. (Dataset).
 \doi{10.25919/pm2n-ww12}.\cr\cr TERN Point-of-truth metadata URL:
 \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/e9484508-c705-4c23-9195-f26d64b9d4f1}
+}
+\item{\strong{AVP: Available phosphorus}}{
+Zund, P. (2022). Soil and Landscape Grid National Soil Attribute Maps
+- Available Phosphorus (3" resolution) - Release 1. Version 1.0.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/6qzh-b979}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/c6ef289b-1ca8-4e53-b8b4-aa97e4706c63}
+}
+\item{\strong{PTO: Total phosphorus}}{
+Malone, B. & Searle, R. (2024). Soil and Landscape Grid National Soil
+Attribute Maps - Total Phosphorus (3" resolution) - Release 2.
+Version 2. Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/7j78-md43}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/be382e63-5ff6-40a9-930f-c84655a5bd87}
+}
+\item{\strong{CEC: Cation exchange capacity}}{
+Malone, B. (2024). Soil and Landscape Grid National Soil Attribute Maps
+- Cation Exchange Capacity (3" resolution) - Release 1. Version 1.0.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/pkva-gf85}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/5b4b2991-bfa6-41df-be33-7009a5d0a5b0}
+}
+\item{\strong{ECE: Effective cation exchange capacity}}{
+Viscarra Rossel, R., Chen, C., Grundy, M., Searle, R., Clifford, D.,
+Odgers, N., Holmes, K., Griffin, T., Liddicoat, C. & Kidd, D. (2014).
+Soil and Landscape Grid National Soil Attribute Maps - Effective Cation
+Exchange Capacity (3" resolution) - Release 1. Version 1. Terrestrial
+Ecosystem Research Network. (Dataset).
+\doi{10.4225/08/546F091C11777}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/0d27cf8b-6627-4f33-8398-1b525bc1a210}
+}
+\item{\strong{DUL: Drained upper limit volumetric water content}}{
+Searle, R. & Nimalka Somarathna, P. (2022). Soil and Landscape Grid
+National Soil Attribute Maps - Drained Upper Limit Volumetric Water
+Content (Percent) (3 arc second resolution) Version 1. Version 1.0.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/jnvd-3a26}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/de9ddc12-b8e4-4ff2-99c4-390227a848aa}
+}
+\item{\strong{L15: 15 bar lower limit volumetric water content}}{
+Searle, R. & Nimalka Somarathna, P. (2022). Soil and Landscape Grid
+National Soil Attribute Maps - 15 Bar Lower Limit Volumetric Water
+Content (Percent) (3 arc second resolution) Version 1. Version 1.0.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/awp8-nv68}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/4443f5df-a0b2-4352-b44b-83f7feb1e27d}
 }
 }
 }

--- a/man/read_slga.Rd
+++ b/man/read_slga.Rd
@@ -26,58 +26,43 @@ read_slga(
 \code{"CI"} (confidence interval).}
 
 \item{api_key}{A \code{character} string containing your \acronym{TERN}
-\acronym{API} key.  Defaults to automatic detection via \code{\link[=get_key]{get_key()}}.}
+\acronym{API} key. Defaults to automatic detection from your
+\code{.Renviron} or \code{.Rprofile}.  See \code{\link[=get_key]{get_key()}} for setup.}
 
 \item{max_tries}{Maximum number of download retries before an error is
-raised.  When \code{NULL} (default), resolved from
-\code{getOption("nert.max_tries", 3L)}.  Pass an integer to override
-for a single call.}
+raised. Default=\code{NULL}, in which case the maximum retry number is
+resolved from the option \code{nert.max_tries} if that option exists.
+(Defaults to 3 retries if \code{nert.max_tries} has not been set.)}
 
 \item{initial_delay}{Initial retry delay in seconds (doubles with each
-attempt).  When \code{NULL} (default), resolved from
-\code{getOption("nert.initial_delay", 1L)}.  Pass an integer to
-override for a single call.}
+attempt). Default=\code{NULL}, in which case the initial delay is
+resolved from the option \code{nert.initial_delay} if that option exists.
+(Defaults to a 1 second initial delay if \code{nert.initial_delay} has
+not been set.)}
 }
 \value{
-A \code{\link[terra:rast]{terra::rast()}} object of the national SLGA mosaic for the
-requested attribute, depth, and statistic.
+A \link[terra:SpatRaster-class]{terra::SpatRaster} object of the requested SLGA soil attribute.
 }
 \description{
-Read Soil and Landscape Grid of Australia (\acronym{SLGA}) Cloud Optimised
-GeoTIFF (\acronym{COG}) files from \acronym{TERN}.  Eight soil attributes
-are available as static 90 m national products, each with six standard
-depth layers and two statistics (estimated value or confidence interval).
+Wrapper around \code{\link[=read_tern]{read_tern()}} for retrieving various Soil and Landscape
+Grid of Australia (SLGA) datasets from the TERN Data Portal. Eight soil
+attributes are available at 90m X 90m spatial resolution across Australia,
+each with six standard depth layers (0-5cm, 5-15cm, 15-30cm, 30-60cm,
+60-100cm, 100-200cm) and two statistics (estimated value, confidence
+interval).
 }
-\section{Supported attributes}{
+\section{Supported soil attributes}{
 
 \describe{
-\item{\code{"AWC"}}{Available Water Capacity (mm)}
-\item{\code{"CLY"}}{Clay content (percent)}
-\item{\code{"SND"}}{Sand content (percent)}
-\item{\code{"SLT"}}{Silt content (percent)}
-\item{\code{"BDW"}}{Bulk Density whole earth (g/cm3)}
-\item{\code{"PHC"}}{pH (CaCl2)}
-\item{\code{"PHW"}}{pH (water)}
-\item{\code{"NTO"}}{Total Nitrogen (percent)}
+\item{\code{"AWC"}}{Available Water Capacity (\%)}
+\item{\code{"CLY"}}{Clay content (\%)}
+\item{\code{"SND"}}{Sand content (\%)}
+\item{\code{"SLT"}}{Silt content (\%)}
+\item{\code{"BDW"}}{Bulk Density (Whole Earth) (g/cm3)}
+\item{\code{"PHC"}}{pH (of 1:5 soil/0.01M CaCl2 extract)}
+\item{\code{"PHW"}}{pH (of 1:5 soil water solution)}
+\item{\code{"NTO"}}{Total Nitrogen (\%)}
 }
-}
-
-\section{Depth layers}{
-
-Six standard \acronym{GlobalSoilMap} depth intervals are available
-(values in cm):
-\tabular{l}{
-\code{"000_005"} — 0--5 cm (default) \cr
-\code{"005_015"} — 5--15 cm \cr
-\code{"015_030"} — 15--30 cm \cr
-\code{"030_060"} — 30--60 cm \cr
-\code{"060_100"} — 60--100 cm \cr
-\code{"100_200"} — 100--200 cm \cr
-}
-
-This is a convenience wrapper around
-\code{read_tern(<attribute>, ...)}; see \code{\link[=read_tern]{read_tern()}} for full
-details and additional datasets.
 }
 
 \examples{
@@ -94,15 +79,66 @@ r_phc <- read_slga("PHC", depth = "030_060", collection = "CI")
 \dontshow{\}) # examplesIf}
 }
 \references{
-AWC: \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/482301c2-2837-4b0b-bf95-4883a04e5ff7}
-
-SLGA: \url{https://esoil.io/TERNLandscapes/Public/Pages/SLGA/}
+\describe{
+\item{\strong{AWC: Available Volumetric Water Capacity}}{
+Searle, R., Nimalka Somarathna, P. & Malone, B. (2023). Soil and
+Landscape Grid National Soil Attribute Maps - Available Volumetric
+Water Capacity (Percent) (3 arc second resolution) Version 2.
+Version 2.0. Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/4jwj-na34}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/482301c2-b9a1-4345-b142-815f9b37890a}
+}
+\item{\strong{CLY: Clay content}}{
+Malone, B. & Searle, R. (2022). Soil and Landscape Grid National
+Soil Attribute Maps - Clay (3" resolution) - Release 2. Version 2.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/hc4s-3130}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/f95dc442-013b-4fad-b31f-91ba86fbe7f5}
+}
+\item{\strong{SND: Sand content}}{
+Malone, B. & Searle, R. (2022). Soil and Landscape Grid National Soil
+Attribute Maps - Sand (3" resolution) - Release 2. Version 2.0.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/rjmy-pa10}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/4224ddff-5fb4-4170-b5ea-c0c500599700}
+}
+\item{\strong{SLT: Silt content}}{
+Malone, B. & Searle, R. (2022). Soil and Landscape Grid National Soil
+Attribute Maps - Silt (3" resolution) - Release 2. Version 2.0.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/2ew1-0w57}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/11375f04-b5cd-46a7-bcac-0e83fcb58605}
+}
+\item{\strong{BDW: Bulk Density (Whole Earth)}}{
+Malone, B. (2023). Soil and Landscape Grid National Soil Attribute
+Maps - Bulk Density - Whole Earth - Release 2. Version 2.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/gxyn-pd07}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/95978aec-6ba8-446b-a721-2b875d9f61a8}
+}
+\item{\strong{PHC: pH (of 1:5 soil/0.01M CaCl2 extract)}}{
+Malone, B. & Searle, R. (2024). Soil and Landscape Grid National Soil
+Attribute Maps - pH - Calcium Chloride (3" resolution) - Release 2.
+Version 2. Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/7320-hw30}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/258afc98-7407-4781-b241-cb0293b4b8aa}
+}
+\item{\strong{PHW: pH (of 1:5 soil water solution)}}{
+Malone, B. (2022). Soil and Landscape Grid National Soil Attribute
+Maps - pH (Water) (3" resolution) - Release 1. Version 1.0.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/37z2-0q10}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/c37439a5-e622-44ab-9c24-bfd632d8203c}
+}
+\item{\strong{NTO: Total nitrogen}}{
+Malone, B. & Searle, R. (2024). Soil and Landscape Grid National Soil
+Attribute Maps - Total Nitrogen (3" resolution) - Release 2. Version 2.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/pm2n-ww12}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/e9484508-c705-4c23-9195-f26d64b9d4f1}
+}
+}
 }
 \seealso{
-Other COGs: 
-\code{\link{read_asc}()},
-\code{\link{read_canopy_height}()},
-\code{\link{read_phenology}()},
-\code{\link{read_tern}()}
+\code{\link[=read_tern]{read_tern()}}
 }
-\concept{COGs}

--- a/man/read_smips.Rd
+++ b/man/read_smips.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/read_smips.R
 \name{read_smips}
 \alias{read_smips}
-\title{Read TERN SMIPS Soil Moisture Data}
+\title{Read SMIPS Soil Moisture Data from TERN}
 \usage{
 read_smips(
   date,
@@ -39,7 +39,7 @@ runoff or overtopping.}
 }}
 
 \item{api_key}{A \code{character} string containing your \acronym{TERN}
-\acronym{API} key.  Defaults to automatic detection from your
+\acronym{API} key. Defaults to automatic detection from your
 \code{.Renviron} or \code{.Rprofile}.  See \code{\link[=get_key]{get_key()}} for setup.}
 
 \item{max_tries}{Maximum number of download retries before an error is

--- a/man/read_smips.Rd
+++ b/man/read_smips.Rd
@@ -60,7 +60,8 @@ A \link[terra:SpatRaster-class]{terra::SpatRaster} object of the requested SMIPS
 Wrapper around \code{\link[=read_tern]{read_tern()}} for retrieving the SMIPS v1.0 daily soil
 moisture data from the TERN Data Portal. SMIPS provides soil moisture
 estimates at roughly 1km X 1km spatial resolution across Australia,
-from 1st January 2015 to approximately 7 days before today.
+from 1st January 2015 onward (updated approximately daily on the TERN
+server).
 }
 \examples{
 \dontshow{if (interactive()) withAutoprint(\{ # examplesIf}

--- a/man/read_smips.Rd
+++ b/man/read_smips.Rd
@@ -14,34 +14,28 @@ read_smips(
 }
 \arguments{
 \item{date}{A day to download (Date or character, e.g.
-\code{"2024-01-15"} or \code{as.Date("2024-01-15")}).  Required.}
+\code{"2024-01-15"} or \code{as.Date("2024-01-15")}).}
 
 \item{collection}{SMIPS collection variant (default \code{"totalbucket"}). Options:
 \describe{
-\item{\code{"totalbucket"}}{\strong{Total soil moisture in the full active layer} (mm).
-Represents the total water stored in all soil layers of the active profile.
-Use for: Overall soil water availability, drought monitoring.
-Output column: \code{SMIPS_totalbucket}}
-\item{\code{"SMindex"}}{\strong{Soil Moisture Index, 0-100\%} (standardized metric).
-Rescaled to 0-100\% for comparison across regions and seasons.
-Use for: Regional comparisons, anomaly detection, percentage-based thresholds.
-Output column: \code{SMIPS_SMindex}}
-\item{\code{"bucket1"}}{\strong{Top soil layer moisture} (mm, typically 0-10 cm).
-Represents water in surface soil where seeds germinate and shallow roots operate.
-Use for: Shallow-rooting plants, seed germination, surface runoff prediction.
-Output column: \code{SMIPS_bucket1}}
-\item{\code{"bucket2"}}{\strong{Second soil layer moisture} (mm, typically 10-40 cm).
-Represents water in intermediate soil depth where many plant roots develop.
-Use for: Typical crop rooting depth, plant-available water.
-Output column: \code{SMIPS_bucket2}}
-\item{\code{"deepD"}}{\strong{Deep soil layer moisture} (mm, typically >40 cm).
-Represents water in deeper soil layers accessed by deep-rooting plants.
-Use for: Deep-rooting trees/shrubs, groundwater recharge, long-term drought.
-Output column: \code{SMIPS_deepD}}
-\item{\code{"runoff"}}{\strong{Surface runoff} (mm).
-Represents water predicted to run off the surface (not infiltrate).
-Use for: Flood risk, erosion modeling, drainage engineering.
-Output column: \code{SMIPS_runoff}}
+\item{\code{"totalbucket"}}{\strong{Soil moisture of the 0-90cm two-bucket store} (mm).
+An estimate of the volumetric soil moisture of the complete 0-90cm
+SMIPS two-bucket soil moisture store.}
+\item{\code{"SMindex"}}{\strong{Soil moisture index, 0-1}.
+A unitless index between 0.0 and 1.0, approximating how full the
+complete SMIPS 0-90cm soil moisture two-bucket store is.}
+\item{\code{"bucket1"}}{\strong{Soil moisture in the upper 0-10cm bucket} (mm).
+An estimate of the volumetric soil moisture of the upper 0-10cm
+soil bucket.}
+\item{\code{"bucket2"}}{\strong{Soil moisture in the lower 10-90cm bucket} (mm).
+An estimate of the volumetric soil moisture of the lower 10-90cm
+soil bucket.}
+\item{\code{"deepD"}}{\strong{Drainage between two buckets} (mm).
+An estimate of the drainage from the top 0-1cm soil bucket through
+to the lower 10-90cm bucket.}
+\item{\code{"runoff"}}{\strong{Runoff/overtopping moisture loss} (mm).
+An estimate of the moisture lost from the top 0-10cm bucket due to
+runoff or overtopping.}
 }}
 
 \item{api_key}{A \code{character} string containing your \acronym{TERN}
@@ -49,46 +43,56 @@ Output column: \code{SMIPS_runoff}}
 \code{.Renviron} or \code{.Rprofile}.  See \code{\link[=get_key]{get_key()}} for setup.}
 
 \item{max_tries}{Maximum number of download retries before an error is
-raised.  When \code{NULL} (default), resolved from
-\code{getOption("nert.max_tries", 3L)}.  Pass an integer to override
-for a single call.}
+raised. Default=\code{NULL}, in which case the maximum retry number is
+resolved from the option \code{nert.max_tries} if that option exists.
+(Defaults to 3 retries if \code{nert.max_tries} has not been set.)}
 
 \item{initial_delay}{Initial retry delay in seconds (doubles with each
-attempt).  When \code{NULL} (default), resolved from
-\code{getOption("nert.initial_delay", 1L)}.  Pass an integer to
-override for a single call.}
+attempt). Default=\code{NULL}, in which case the initial delay is
+resolved from the option \code{nert.initial_delay} if that option exists.
+(Defaults to a 1 second initial delay if \code{nert.initial_delay} has
+not been set.)}
 }
 \value{
-A \code{\link[terra:rast]{terra::rast()}} object of the requested SMIPS collection.
+A \link[terra:SpatRaster-class]{terra::SpatRaster} object of the requested SMIPS collection.
 }
 \description{
-Wrapper around \code{\link[=read_tern]{read_tern()}} for TERN/SMIPS daily soil moisture data.
-Provides soil moisture estimates at 1 km resolution from November 2015
-to approximately 7 days before today.
+Wrapper around \code{\link[=read_tern]{read_tern()}} for retrieving the SMIPS v1.0 daily soil
+moisture data from the TERN Data Portal. SMIPS provides soil moisture
+estimates at roughly 1km X 1km spatial resolution across Australia,
+from 1st January 2015 to approximately 7 days before today.
 }
 \examples{
 \dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
-# Total bucket soil moisture (default)
+# Total volumetric soil moisture across both buckets (default)
 r <- read_smips("2024-01-15")
 autoplot(r)
 
-# Soil moisture index (0-100\%)
+# Soil moisture index (0-1)
 r_smi <- read_smips("2024-01-15", collection = "SMindex")
 
-# Top soil bucket (shallow rooting plants)
+# Upper soil bucket
 r_bucket1 <- read_smips("2024-01-15", collection = "bucket1")
 
-# Deep soil layer (deep rooting plants)
+# Lower soil bucket
+r_bucket2 <- read_smips("2024-01-15", collection = "bucket2")
+
+# Drainage between upper and lower buckets
 r_deep <- read_smips("2024-01-15", collection = "deepD")
 
-# Surface runoff
+# Top bucket runoff
 r_runoff <- read_smips("2024-01-15", collection = "runoff")
 \dontshow{\}) # examplesIf}
 }
 \references{
-SMIPS portal:
+Stenson, M., Searle, R., Malone, B., Sommer, A., Renzullo, L. & Di, H.
+(2021): Australia wide daily volumetric soil moisture estimates.
+Version 1.0. Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25901/b020-nm39}.
+
+TERN SMIPS Point-of-truth metadata URL:
 \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/d1995ee8-53f0-4a7d-91c2-ad5e4a23e5e0}
 }
 \seealso{
-\code{\link[=read_tern]{read_tern()}}, \code{\link[=read_aet]{read_aet()}}, \code{\link[=read_asc]{read_asc()}}
+\code{\link[=read_tern]{read_tern()}}
 }

--- a/man/read_soil_diversity.Rd
+++ b/man/read_soil_diversity.Rd
@@ -19,42 +19,32 @@ read_soil_diversity(
 \code{3}.}
 
 \item{api_key}{A \code{character} string containing your \acronym{TERN}
-\acronym{API} key.  Defaults to automatic detection via \code{\link[=get_key]{get_key()}}.}
+\acronym{API} key. Defaults to automatic detection from your
+\code{.Renviron} or \code{.Rprofile}. See \code{\link[=get_key]{get_key()}} for setup.}
 
 \item{max_tries}{Maximum number of download retries before an error is
-raised.  When \code{NULL} (default), resolved from
-\code{getOption("nert.max_tries", 3L)}.  Pass an integer to override
-for a single call.}
+raised. Default=\code{NULL}, in which case the maximum retry number is
+resolved from the option \code{nert.max_tries} if that option exists.
+(Defaults to 3 retries if \code{nert.max_tries} has not been set.)}
 
 \item{initial_delay}{Initial retry delay in seconds (doubles with each
-attempt).  When \code{NULL} (default), resolved from
-\code{getOption("nert.initial_delay", 1L)}.  Pass an integer to
-override for a single call.}
+attempt). Default=\code{NULL}, in which case the initial delay is
+resolved from the option \code{nert.initial_delay} if that option exists.
+(Defaults to a 1 second initial delay if \code{nert.initial_delay} has
+not been set.)}
 }
 \value{
-A \code{\link[terra:rast]{terra::rast()}} object of the national Soil Beta Diversity
-mosaic for the requested organism and NMDS axis.
+A \link[terra:SpatRaster-class]{terra::SpatRaster} object of the requested Beta Diversity NMDS axis.
 }
 \description{
-Read Soil Beta Diversity Cloud Optimised GeoTIFF (\acronym{COG}) files
-from \acronym{TERN}.  This product provides Non-metric Multidimensional
-Scaling (\acronym{NMDS}) axes 1--3 for soil Bacteria and Fungi
-communities across Australia at 90 m resolution.
+Wrapper around \code{\link[=read_tern]{read_tern()}} for retrieving the v1.0 datasets for
+soil bacteria and soil fungi Beta Diversity from the TERN Data Portal.
+The Beta Diversity datasets were constructed using Digital Soil Mapping
+techniques together with Biome of Australia Soil Environments (BASE)
+DNA sequences, and provide Non-metric MultiDimensional Scaling (NMDS)
+axes for soil bacteria and fungi at 90m X 90m spatial resolution across
+Australia.
 }
-\section{Collections}{
-
-\describe{
-\item{\code{"Bacteria"}}{Bacterial community beta diversity (default).}
-\item{\code{"Fungi"}}{Fungal community beta diversity.}
-}
-
-This is a static product (no date argument required).
-
-This is a convenience wrapper around
-\code{read_tern("SOILDIV", ...)}; see \code{\link[=read_tern]{read_tern()}} for full
-details and additional datasets.
-}
-
 \examples{
 \dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
 # Read bacterial diversity NMDS axis 1
@@ -67,14 +57,14 @@ autoplot(r_f2)
 \dontshow{\}) # examplesIf}
 }
 \references{
-\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/4a428d52-d15c-4bfc-8a67-80697f8c0aa0}
+Dobarco, M., Wadoux, A. & Xue, P. (2024). Soil and Landscape Grid National
+Soil Attribute Maps - Soil Bacteria and Fungi Beta Diversity (3"
+resolution) - Release 1. Version 1.0. Terrestrial Ecosystem Research
+Network. (Dataset). \doi{10.25919/4x7n-y874}.
+
+TERN Soil Beta Diversity Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/4a428d52-dda6-4097-8dd9-d3ec63973029}
 }
 \seealso{
-Other COGs: 
-\code{\link{read_asc}()},
-\code{\link{read_canopy_height}()},
-\code{\link{read_phenology}()},
-\code{\link{read_slga}()},
-\code{\link{read_tern}()}
+\code{\link[=read_tern]{read_tern()}}
 }
-\concept{COGs}

--- a/man/read_tern.Rd
+++ b/man/read_tern.Rd
@@ -244,7 +244,6 @@ Land Surface Phenology: \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/c
 }
 \seealso{
 Other COGs: 
-\code{\link{read_asc}()},
-\code{\link{read_canopy_height}()}
+\code{\link{read_asc}()}
 }
 \concept{COGs}

--- a/man/read_tern.Rd
+++ b/man/read_tern.Rd
@@ -246,7 +246,6 @@ Land Surface Phenology: \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/c
 Other COGs: 
 \code{\link{read_asc}()},
 \code{\link{read_canopy_height}()},
-\code{\link{read_phenology}()},
-\code{\link{read_slga}()}
+\code{\link{read_phenology}()}
 }
 \concept{COGs}

--- a/man/read_tern.Rd
+++ b/man/read_tern.Rd
@@ -175,7 +175,10 @@ from the OzTreeMap project. No function arguments required.
 \code{"EGS"} (End of Growing Season), \code{"LGS"} (Length of Growing Season),
 \code{"EVI1"} (Minimum EVI before peak), \code{"EVI2"} (Minimum EVI after peak),
 \code{"EVIP"} (EVI at Peak of Growing Season),
-\code{"EVII"} (Integral of EVI under growing season curve).}
+\code{"EVII"} (Integral of EVI under growing season curve),
+\code{"SGS_month"} (Start of Growing Season, monthly resolution),
+\code{"PGS_month"} (Peak of the Growing Season, monthly resolution),
+\code{"EGS_month"} (End of Growing Season, monthly resolution).}
 }
 }
 

--- a/man/read_tern.Rd
+++ b/man/read_tern.Rd
@@ -245,7 +245,6 @@ Land Surface Phenology: \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/c
 \seealso{
 Other COGs: 
 \code{\link{read_asc}()},
-\code{\link{read_canopy_height}()},
-\code{\link{read_phenology}()}
+\code{\link{read_canopy_height}()}
 }
 \concept{COGs}

--- a/man/read_tern.Rd
+++ b/man/read_tern.Rd
@@ -39,7 +39,7 @@ attempt).  When \code{NULL} (default), resolved from
 override for a single call.}
 }
 \value{
-A \code{\link[terra:rast]{terra::rast()}} object of the national mosaic for the
+A \link[terra:SpatRaster-class]{terra::SpatRaster} object of the national mosaic for the
 requested dataset (and, where applicable, date/collection).
 }
 \description{
@@ -47,29 +47,35 @@ A unified interface for reading Cloud Optimised GeoTIFF (\acronym{COG})
 data from \acronym{TERN} and related repositories.  Dispatches to a
 dataset-specific handler based on \code{dataset_id} and passes any
 additional arguments through \code{...}.  The returned object is a
-\code{\link[terra:rast]{terra::rast()}} that can be plotted, cropped, or extracted with standard
-\pkg{terra} or \pkg{tidyterra} workflows.
+\link[terra:SpatRaster-class]{terra::SpatRaster} that can be plotted, cropped, or extracted with
+standard \pkg{terra} or \pkg{tidyterra} workflows.
 }
 \section{Dataset aliases}{
 
 In addition to full \acronym{TERN} portal keys and 8-character prefixes,
 \code{read_tern()} accepts short human-readable aliases (case-insensitive):
 \tabular{lll}{
-\strong{Alias}        \tab \strong{Dataset ID}        \tab \strong{Description} \cr
-\code{"SMIPS"}         \tab \code{TERN/d1995ee8} \tab Daily soil moisture (~1 km) \cr
-\code{"ASC"}           \tab \code{TERN/15728dba} \tab Australian Soil Classification (90 m) \cr
-\code{"AET"}           \tab \code{TERN/9fefa68b} \tab Monthly evapotranspiration (CMRSET) \cr
-\code{"AWC"}           \tab \code{TERN/482301c2} \tab Available Water Capacity (90 m) \cr
-\code{"CLY"}           \tab SLGA                 \tab Clay content (90 m) \cr
-\code{"SND"}           \tab SLGA                 \tab Sand content (90 m) \cr
-\code{"SLT"}           \tab SLGA                 \tab Silt content (90 m) \cr
-\code{"BDW"}           \tab SLGA                 \tab Bulk density whole earth (90 m) \cr
-\code{"PHC"}           \tab SLGA                 \tab pH CaCl2 (90 m) \cr
-\code{"PHW"}           \tab SLGA                 \tab pH water (90 m) \cr
-\code{"NTO"}           \tab SLGA                 \tab Total Nitrogen (90 m) \cr
-\code{"SOILDIV"}       \tab \code{TERN/4a428d52} \tab Soil Beta Diversity (90 m) \cr
-\code{"CANOPY"}        \tab \code{TERN/36c98155} \tab Canopy Height (30 m) \cr
-\code{"PHENOLOGY"}     \tab \code{TERN/2bb0c81a} \tab Land Surface Phenology (500 m) \cr
+\strong{Alias} \tab \strong{Dataset ID} \tab \strong{Description} \cr
+\code{"SMIPS"} \tab \code{TERN/d1995ee8} \tab Daily soil moisture (~1 km) \cr
+\code{"ASC"} \tab \code{TERN/15728dba} \tab Australian Soil Classification (90 m) \cr
+\code{"AET"} \tab \code{TERN/9fefa68b} \tab Monthly evapotranspiration (CMRSET) \cr
+\code{"AWC"} \tab \code{TERN/482301c2} \tab Available Water Capacity (90 m) \cr
+\code{"CLY"} \tab SLGA \tab Clay content (90 m) \cr
+\code{"SND"} \tab SLGA \tab Sand content (90 m) \cr
+\code{"SLT"} \tab SLGA \tab Silt content (90 m) \cr
+\code{"BDW"} \tab SLGA \tab Bulk density whole earth (90 m) \cr
+\code{"PHC"} \tab SLGA \tab pH CaCl2 (90 m) \cr
+\code{"PHW"} \tab SLGA \tab pH water (90 m) \cr
+\code{"NTO"} \tab SLGA \tab Total Nitrogen (90 m) \cr
+\code{"AVP"} \tab SLGA \tab Available Phosphorus (90 m) \cr
+\code{"PTO"} \tab SLGA \tab Total Phosphorus (90 m) \cr
+\code{"CEC"} \tab SLGA \tab Cation Exchange Capacity (90 m) \cr
+\code{"ECE"} \tab SLGA \tab Effective Cation Exchange Capacity (90 m) \cr
+\code{"DUL"} \tab SLGA \tab Drained Upper Limit water content (90 m) \cr
+\code{"L15"} \tab SLGA \tab 15 Bar Lower Limit water content (90 m) \cr
+\code{"SOILDIV"} \tab \code{TERN/4a428d52} \tab Soil Beta Diversity (90 m) \cr
+\code{"CANOPY"} \tab \code{TERN/36c98155} \tab Canopy Height (30 m) \cr
+\code{"PHENOLOGY"} \tab \code{TERN/2bb0c81a} \tab Land Surface Phenology (500 m) \cr
 }
 Convenience wrappers \code{\link[=read_smips]{read_smips()}}, \code{\link[=read_asc]{read_asc()}}, \code{\link[=read_aet]{read_aet()}},
 \code{\link[=read_slga]{read_slga()}}, \code{\link[=read_soil_diversity]{read_soil_diversity()}}, \code{\link[=read_canopy_height]{read_canopy_height()}}, and
@@ -86,7 +92,7 @@ Convenience wrappers \code{\link[=read_smips]{read_smips()}}, \code{\link[=read_
 \code{"SMindex"}, \code{"bucket1"}, \code{"bucket2"},
 \code{"deepD"}, or \code{"runoff"}.}
 }
-Data availability: 2015-11-20 to approximately 7 days before today.
+Data availability: 2015-01-01 to approximately 7 days before today.
 }
 
 \section{ASC -- Australian Soil Classification (\code{"TERN/15728dba"})}{
@@ -94,7 +100,7 @@ Data availability: 2015-11-20 to approximately 7 days before today.
 \describe{
 \item{\code{collection}}{One of \code{"EV"} (estimated soil order
 class, default) or \code{"CI"} (confusion index -- a measure of
-mapping reliability).  No \code{date} argument required; this is a
+mapping uncertainty).  No \code{date} argument required; this is a
 static product.}
 }
 }
@@ -109,12 +115,12 @@ snapped to the first of the month internally.}
 \item{\code{collection}}{One of \code{"ETa"} (primary AET band in
 mm/month, default) or \code{"pixel_qa"} (quality assurance flags).}
 }
-Data availability: 2000-02-01 onwards.
+Data availability: 1987-05-01 onwards.
 }
 
 \section{SLGA soil attributes (\code{"AWC"}, \code{"CLY"}, etc.)}{
 
-Eight \acronym{SLGA} (Soil and Landscape Grid of Australia) soil
+14 \acronym{SLGA} (Soil and Landscape Grid of Australia) soil
 attributes are available as static 90 m products, each with six standard
 depth layers and two statistics:
 \describe{
@@ -126,7 +132,7 @@ or \code{"CI"} (confidence interval).}
 }
 Supported attributes (use as the \code{dataset_id} alias):
 \describe{
-\item{\code{"AWC"}}{Available Water Capacity (mm)}
+\item{\code{"AWC"}}{Available Water Capacity (percent)}
 \item{\code{"CLY"}}{Clay content (percent)}
 \item{\code{"SND"}}{Sand content (percent)}
 \item{\code{"SLT"}}{Silt content (percent)}
@@ -134,6 +140,12 @@ Supported attributes (use as the \code{dataset_id} alias):
 \item{\code{"PHC"}}{pH (CaCl2)}
 \item{\code{"PHW"}}{pH (water)}
 \item{\code{"NTO"}}{Total Nitrogen (percent)}
+\item{\code{"AVP"}}{Available Phosphorus (mg/kg)}
+\item{\code{"PTO"}}{Total Phosphorus (percent)}
+\item{\code{"CEC"}}{Cation Exchange Capacity (meq/100g)}
+\item{\code{"ECE"}}{Effective Cation Exchange Capacity (meq/100g)}
+\item{\code{"DUL"}}{Drained Upper Limit volumetric water content (percent)}
+\item{\code{"L15"}}{15 Bar Lower Limit volumetric water content (percent)}
 }
 Convenience wrapper: \code{\link[=read_slga]{read_slga()}}.
 }
@@ -151,8 +163,9 @@ Static 90 m product.  Convenience wrapper: \code{\link[=read_soil_diversity]{rea
 
 \section{Canopy Height (\code{"CANOPY"}, \code{TERN/36c98155})}{
 
-Single static 30 m composite from the OzTreeMap project.  No additional
-arguments required.  Convenience wrapper: \code{\link[=read_canopy_height]{read_canopy_height()}}.
+Single static 30 m best-pick composite from the OzTreeMap project.
+No additional arguments required.
+Convenience wrapper: \code{\link[=read_canopy_height]{read_canopy_height()}}.
 }
 
 \section{Land Surface Phenology (\code{"PHENOLOGY"}, \code{TERN/2bb0c81a})}{
@@ -161,13 +174,13 @@ arguments required.  Convenience wrapper: \code{\link[=read_canopy_height]{read_
 \item{\code{year}}{Required.  An integer year (2003--2018).}
 \item{\code{season}}{Season number: \code{1} (default) or \code{2}.}
 \item{\code{collection}}{Phenology metric — one of \code{"SGS"}
-(Start of Growing Season, default), \code{"PGS"} (Peak),
-\code{"EGS"} (End), \code{"LGS"} (Length), \code{"SOS"} (Start of
-Season), \code{"POS"} (Peak of Season), \code{"EOS"} (End of Season),
-\code{"LOS"} (Length of Season), \code{"ROG"} (Rate of Greening),
-\code{"ROS"} (Rate of Senescence).}
+(Start of Growing Season, default), \code{"PGS"} (Peak of Growing Season),
+\code{"EGS"} (End of Growing Season), \code{"LGS"} (Length of Growing Season),
+\code{"EVI1"} (Minimum EVI before peak), \code{"EVI2"} (Minimum EVI after peak),
+\code{"EVIP"} (EVI at Peak of Growing Season),
+\code{"EVII"} (Integral of EVI under growing season curve).}
 }
-500 m MODIS resolution.  Convenience wrapper: \code{\link[=read_phenology]{read_phenology()}}.
+500 m resolution.  Convenience wrapper: \code{\link[=read_phenology]{read_phenology()}}.
 }
 
 \section{Datasets not accessible}{
@@ -200,12 +213,11 @@ Per-call values supplied via the \code{max_tries} or
 \preformatted{
   options(nert.max_tries = 5L, nert.initial_delay = 2L)
 }
-Closes \href{https://github.com/AAGI-AUS/nert/issues/20}{AAGI-AUS/nert#20}.
 }
 
 \examples{
 \dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
-# Using aliases (recommended) ----------------------------------------
+# Using aliases (recommended)
 r <- read_tern("SMIPS", date = "2024-01-15")
 r_asc <- read_tern("ASC")
 autoplot(r_asc)
@@ -223,23 +235,16 @@ r_ch <- read_tern("CANOPY")
 # Land Surface Phenology
 r_phen <- read_tern("PHENOLOGY", year = 2018, collection = "SGS")
 
-# Full TERN keys still work ----------------------------------------
+# Full TERN keys still work
 r2 <- read_tern("TERN/d1995ee8", date = "2024-01-15")
 \dontshow{\}) # examplesIf}
 }
 \references{
 SMIPS: \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/d1995ee8-53f0-4a7d-91c2-ad5e4a23e5e0}
-
 ASC: \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/15728dba-b49c-4da5-9073-13d8abe67d7c}
-
 AET: \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/9fefa68b-dbed-4c20-88db-a9429fb4ba97}
-
 AWC: \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/482301c2-2837-4b0b-bf95-4883a04e5ff7}
-
 Soil Beta Diversity: \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/4a428d52-d15c-4bfc-8a67-80697f8c0aa0}
-
 Canopy Height: \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/36c98155-c137-44b8-b4e0-6a3e824bbfba}
-
 Land Surface Phenology: \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/2bb0c81a-5a09-4a0e-bd86-5cd2be8def26}
 }
-\concept{COGs}

--- a/man/read_tern.Rd
+++ b/man/read_tern.Rd
@@ -247,7 +247,6 @@ Other COGs:
 \code{\link{read_asc}()},
 \code{\link{read_canopy_height}()},
 \code{\link{read_phenology}()},
-\code{\link{read_slga}()},
-\code{\link{read_soil_diversity}()}
+\code{\link{read_slga}()}
 }
 \concept{COGs}

--- a/man/read_tern.Rd
+++ b/man/read_tern.Rd
@@ -242,8 +242,4 @@ Canopy Height: \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.se
 
 Land Surface Phenology: \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/2bb0c81a-5a09-4a0e-bd86-5cd2be8def26}
 }
-\seealso{
-Other COGs: 
-\code{\link{read_asc}()}
-}
 \concept{COGs}

--- a/man/read_tern.Rd
+++ b/man/read_tern.Rd
@@ -24,31 +24,31 @@ aliases.}
 etc.  See the relevant section above for each dataset.}
 
 \item{api_key}{A \code{character} string containing your \acronym{TERN}
-\acronym{API} key.  Defaults to automatic detection from your
-\code{.Renviron} or \code{.Rprofile}.  See \code{\link{get_key}} for
-setup instructions.}
+\acronym{API} key. Defaults to automatic detection from your
+\code{.Renviron} or \code{.Rprofile}.  See \code{\link[=get_key]{get_key()}} for setup.}
 
 \item{max_tries}{Maximum number of download retries before an error is
-raised.  When \code{NULL} (default), resolved from
-\code{getOption("nert.max_tries", 3L)}.  Pass an integer to override
-for a single call.}
+raised. Default=\code{NULL}, in which case the maximum retry number is
+resolved from the option \code{nert.max_tries} if that option exists.
+(Defaults to 3 retries if \code{nert.max_tries} has not been set.)}
 
 \item{initial_delay}{Initial retry delay in seconds (doubles with each
-attempt).  When \code{NULL} (default), resolved from
-\code{getOption("nert.initial_delay", 1L)}.  Pass an integer to
-override for a single call.}
+attempt). Default=\code{NULL}, in which case the initial delay is
+resolved from the option \code{nert.initial_delay} if that option exists.
+(Defaults to a 1 second initial delay if \code{nert.initial_delay} has
+not been set.)}
 }
 \value{
-A \link[terra:SpatRaster-class]{terra::SpatRaster} object of the national mosaic for the
-requested dataset (and, where applicable, date/collection).
+A \link[terra:SpatRaster-class]{terra::SpatRaster} object for the requested dataset.
 }
 \description{
 A unified interface for reading Cloud Optimised GeoTIFF (\acronym{COG})
-data from \acronym{TERN} and related repositories.  Dispatches to a
-dataset-specific handler based on \code{dataset_id} and passes any
-additional arguments through \code{...}.  The returned object is a
-\link[terra:SpatRaster-class]{terra::SpatRaster} that can be plotted, cropped, or extracted with
-standard \pkg{terra} or \pkg{tidyterra} workflows.
+data from the \acronym{TERN} Data Portal. This function effectively
+dispatches to dataset-specific handlers based on the dataset requested
+(e.g., SMIPS, SLGA, AET, and so on), and passes any additional arguments
+through \code{...}.  The returned object is a \link[terra:SpatRaster-class]{terra::SpatRaster} that
+can be plotted, cropped, or extracted with standard \pkg{terra} or
+\pkg{tidyterra} workflows.
 }
 \section{Dataset aliases}{
 
@@ -58,77 +58,77 @@ In addition to full \acronym{TERN} portal keys and 8-character prefixes,
 \strong{Alias} \tab \strong{Dataset ID} \tab \strong{Description} \cr
 \code{"SMIPS"} \tab \code{TERN/d1995ee8} \tab Daily soil moisture (~1 km) \cr
 \code{"ASC"} \tab \code{TERN/15728dba} \tab Australian Soil Classification (90 m) \cr
-\code{"AET"} \tab \code{TERN/9fefa68b} \tab Monthly evapotranspiration (CMRSET) \cr
+\code{"AET"} \tab \code{TERN/9fefa68b} \tab Monthly evapotranspiration via CMRSET (30 m) \cr
 \code{"AWC"} \tab \code{TERN/482301c2} \tab Available Water Capacity (90 m) \cr
-\code{"CLY"} \tab SLGA \tab Clay content (90 m) \cr
-\code{"SND"} \tab SLGA \tab Sand content (90 m) \cr
-\code{"SLT"} \tab SLGA \tab Silt content (90 m) \cr
-\code{"BDW"} \tab SLGA \tab Bulk density whole earth (90 m) \cr
-\code{"PHC"} \tab SLGA \tab pH CaCl2 (90 m) \cr
-\code{"PHW"} \tab SLGA \tab pH water (90 m) \cr
-\code{"NTO"} \tab SLGA \tab Total Nitrogen (90 m) \cr
-\code{"AVP"} \tab SLGA \tab Available Phosphorus (90 m) \cr
-\code{"PTO"} \tab SLGA \tab Total Phosphorus (90 m) \cr
-\code{"CEC"} \tab SLGA \tab Cation Exchange Capacity (90 m) \cr
-\code{"ECE"} \tab SLGA \tab Effective Cation Exchange Capacity (90 m) \cr
-\code{"DUL"} \tab SLGA \tab Drained Upper Limit water content (90 m) \cr
-\code{"L15"} \tab SLGA \tab 15 Bar Lower Limit water content (90 m) \cr
+\code{"CLY"} \tab \code{TERN/f95dc442} \tab Clay content (90 m) \cr
+\code{"SND"} \tab \code{TERN/4224ddff} \tab Sand content (90 m) \cr
+\code{"SLT"} \tab \code{TERN/11375f04} \tab Silt content (90 m) \cr
+\code{"BDW"} \tab \code{TERN/95978aec} \tab Bulk density whole earth (90 m) \cr
+\code{"PHC"} \tab \code{TERN/258afc98} \tab pH CaCl2 (90 m) \cr
+\code{"PHW"} \tab \code{TERN/c37439a5} \tab pH water (90 m) \cr
+\code{"NTO"} \tab \code{TERN/e9484508} \tab Total Nitrogen (90 m) \cr
+\code{"AVP"} \tab \code{TERN/c6ef289b} \tab Available Phosphorus (90 m) \cr
+\code{"PTO"} \tab \code{TERN/be382e63} \tab Total Phosphorus (90 m) \cr
+\code{"CEC"} \tab \code{TERN/5b4b2991} \tab Cation Exchange Capacity (90 m) \cr
+\code{"ECE"} \tab \code{TERN/0d27cf8b} \tab Effective Cation Exchange Capacity (90 m) \cr
+\code{"DUL"} \tab \code{TERN/de9ddc12} \tab Drained Upper Limit water content (90 m) \cr
+\code{"L15"} \tab \code{TERN/4443f5df} \tab 15 Bar Lower Limit water content (90 m) \cr
 \code{"SOILDIV"} \tab \code{TERN/4a428d52} \tab Soil Beta Diversity (90 m) \cr
 \code{"CANOPY"} \tab \code{TERN/36c98155} \tab Canopy Height (30 m) \cr
 \code{"PHENOLOGY"} \tab \code{TERN/2bb0c81a} \tab Land Surface Phenology (500 m) \cr
 }
 Convenience wrappers \code{\link[=read_smips]{read_smips()}}, \code{\link[=read_asc]{read_asc()}}, \code{\link[=read_aet]{read_aet()}},
 \code{\link[=read_slga]{read_slga()}}, \code{\link[=read_soil_diversity]{read_soil_diversity()}}, \code{\link[=read_canopy_height]{read_canopy_height()}}, and
-\code{\link[=read_phenology]{read_phenology()}} are also provided for direct access to each dataset.
+\code{\link[=read_phenology]{read_phenology()}} are also provided for simplified access to each dataset.
 }
 
-\section{SMIPS — daily soil moisture (\code{"TERN/d1995ee8"})}{
+\section{SMIPS — daily soil moisture (\code{"SMIPS"})}{
 
 \describe{
-\item{\code{date}}{Required.  A single day to query, \emph{e.g.}
+\item{\code{date}}{Required. A single day to query, \emph{e.g.}
 \code{"2024-01-15"} or \code{as.Date("2024-01-15")}.  Both
-\code{Character} and \code{Date} classes are accepted.}
+\code{character} and \code{Date} classes are accepted.}
 \item{\code{collection}}{One of \code{"totalbucket"} (default),
 \code{"SMindex"}, \code{"bucket1"}, \code{"bucket2"},
 \code{"deepD"}, or \code{"runoff"}.}
 }
-Data availability: 2015-01-01 to approximately 7 days before today.
+Data availability: from 2005-01-01 to today. (Updated regularly.)
 }
 
-\section{ASC -- Australian Soil Classification (\code{"TERN/15728dba"})}{
+\section{ASC -- Australian Soil Classification (\code{"ASC"})}{
 
 \describe{
 \item{\code{collection}}{One of \code{"EV"} (estimated soil order
-class, default) or \code{"CI"} (confusion index -- a measure of
-mapping uncertainty).  No \code{date} argument required; this is a
-static product.}
+class, default) or \code{"CI"} (confusion index -- a measure of the
+classification uncertainty).}
 }
 }
 
-\section{AET -- Actual Evapotranspiration/CMRSET (\code{"TERN/9fefa68b"})}{
+\section{AET -- Actual Evapotranspiration/CMRSET (\code{"AET"})}{
 
 \describe{
-\item{\code{date}}{Required.  A month to query, \emph{e.g.}
+\item{\code{date}}{Required. A month to query, \emph{e.g.}
 \code{"2023-06-01"} or \code{as.Date("2023-06-01")}.  Both
-\code{Character} and \code{Date} classes are accepted.  The value is
-snapped to the first of the month internally.}
+\code{character} and \code{Date} classes are accepted.  The value is
+snapped to the first of the month.}
 \item{\code{collection}}{One of \code{"ETa"} (primary AET band in
-mm/month, default) or \code{"pixel_qa"} (quality assurance flags).}
+mm/month, default) or \code{"pixel_qa"} (quality assurance attributes).}
 }
-Data availability: 1987-05-01 onwards.
+Data availability: 1987-05-01 onward, monthly.
 }
 
 \section{SLGA soil attributes (\code{"AWC"}, \code{"CLY"}, etc.)}{
 
 14 \acronym{SLGA} (Soil and Landscape Grid of Australia) soil
 attributes are available as static 90 m products, each with six standard
-depth layers and two statistics:
+depth layers and three statistics:
 \describe{
 \item{\code{depth}}{One of \code{"000_005"} (default), \code{"005_015"},
 \code{"015_030"}, \code{"030_060"}, \code{"060_100"}, or
 \code{"100_200"} (cm).}
-\item{\code{collection}}{One of \code{"EV"} (estimated value, default)
-or \code{"CI"} (confidence interval).}
+\item{\code{collection}}{One of \code{"EV"} (estimated value, default),
+\code{"05"} (lower percentile limit for the 95\% confidence interval)
+or \code{"95"} (upper percentile limit for the confidence interval).}
 }
 Supported attributes (use as the \code{dataset_id} alias):
 \describe{
@@ -147,31 +147,28 @@ Supported attributes (use as the \code{dataset_id} alias):
 \item{\code{"DUL"}}{Drained Upper Limit volumetric water content (percent)}
 \item{\code{"L15"}}{15 Bar Lower Limit volumetric water content (percent)}
 }
-Convenience wrapper: \code{\link[=read_slga]{read_slga()}}.
 }
 
-\section{Soil Beta Diversity (\code{"SOILDIV"}, \code{TERN/4a428d52})}{
+\section{Soil Beta Diversity (\code{"SOILDIV"})}{
 
 \describe{
 \item{\code{collection}}{One of \code{"Bacteria"} (default) or
 \code{"Fungi"}.}
-\item{\code{axis}}{NMDS axis number: \code{1} (default), \code{2}, or
+\item{\code{axis}}{NMDS axis: \code{1} (default), \code{2}, or
 \code{3}.}
 }
-Static 90 m product.  Convenience wrapper: \code{\link[=read_soil_diversity]{read_soil_diversity()}}.
 }
 
-\section{Canopy Height (\code{"CANOPY"}, \code{TERN/36c98155})}{
+\section{Canopy Height (\code{"CANOPY"})}{
 
-Single static 30 m best-pick composite from the OzTreeMap project.
-No additional arguments required.
-Convenience wrapper: \code{\link[=read_canopy_height]{read_canopy_height()}}.
+Single static 30 m X 30 m best-pick canopy height model composite,
+from the OzTreeMap project. No function arguments required.
 }
 
-\section{Land Surface Phenology (\code{"PHENOLOGY"}, \code{TERN/2bb0c81a})}{
+\section{Land Surface Phenology (\code{"PHENOLOGY"})}{
 
 \describe{
-\item{\code{year}}{Required.  An integer year (2003--2018).}
+\item{\code{year}}{Required. An integer year (2003--2018).}
 \item{\code{season}}{Season number: \code{1} (default) or \code{2}.}
 \item{\code{collection}}{Phenology metric — one of \code{"SGS"}
 (Start of Growing Season, default), \code{"PGS"} (Peak of Growing Season),
@@ -180,7 +177,6 @@ Convenience wrapper: \code{\link[=read_canopy_height]{read_canopy_height()}}.
 \code{"EVIP"} (EVI at Peak of Growing Season),
 \code{"EVII"} (Integral of EVI under growing season curve).}
 }
-500 m resolution.  Convenience wrapper: \code{\link[=read_phenology]{read_phenology()}}.
 }
 
 \section{Datasets not accessible}{
@@ -222,29 +218,172 @@ r <- read_tern("SMIPS", date = "2024-01-15")
 r_asc <- read_tern("ASC")
 autoplot(r_asc)
 
-# SLGA soil attributes — depth and collection
+# SLGA soil attributes
 r_clay <- read_tern("CLY", depth = "000_005")
-r_awc  <- read_tern("AWC", depth = "015_030", collection = "CI")
+r_awc_upper  <- read_tern("AWC", depth = "015_030", collection = "95")
+r_awc_lower  <- read_tern("AWC", depth = "015_030", collection = "05")
 
 # Soil Beta Diversity
 r_bact <- read_tern("SOILDIV", collection = "Bacteria", axis = 1)
 
-# Canopy Height (single static product)
+# Canopy Height
 r_ch <- read_tern("CANOPY")
 
 # Land Surface Phenology
 r_phen <- read_tern("PHENOLOGY", year = 2018, collection = "SGS")
 
-# Full TERN keys still work
+# Full TERN dataset IDs also work
 r2 <- read_tern("TERN/d1995ee8", date = "2024-01-15")
 \dontshow{\}) # examplesIf}
 }
 \references{
-SMIPS: \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/d1995ee8-53f0-4a7d-91c2-ad5e4a23e5e0}
-ASC: \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/15728dba-b49c-4da5-9073-13d8abe67d7c}
-AET: \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/9fefa68b-dbed-4c20-88db-a9429fb4ba97}
-AWC: \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/482301c2-2837-4b0b-bf95-4883a04e5ff7}
-Soil Beta Diversity: \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/4a428d52-d15c-4bfc-8a67-80697f8c0aa0}
-Canopy Height: \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/36c98155-c137-44b8-b4e0-6a3e824bbfba}
-Land Surface Phenology: \url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/2bb0c81a-5a09-4a0e-bd86-5cd2be8def26}
+\describe{
+\item{\strong{SMIPS: Daily volumetric soil moisture}}{
+Stenson, M., Searle, R., Malone, B., Sommer, A., Renzullo, L. & Di, H.
+(2021): Australia wide daily volumetric soil moisture estimates.
+Version 1.0. Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25901/b020-nm39}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/d1995ee8-53f0-4a7d-91c2-ad5e4a23e5e0}
+}
+\item{\strong{ASC: Australian Soil Classification Map}}{
+Searle, R. (2021). Australian Soil Classification Map. Version 1.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25901/edyr-wg85}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/15728dba-b49c-4da5-9073-13d8abe67d7c}
+}
+\item{\strong{AET: Actual Evapotranspiration using the CMRSET algorithm}}{
+McVicar, T., Vleeshouwer, J., Van Niel, T., Guerschman, J. &
+Peña-Arancibia, J. (2022). Actual Evapotranspiration for Australia
+using CMRSET algorithm. Version 1.0. Terrestrial Ecosystem Research
+Network. (Dataset). \doi{10.25901/gg27-ck96}.\cr\cr
+TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/9fefa68b-dbed-4c20-88db-a9429fb4ba97}
+}
+\item{\strong{AWC: SLGA Attribute - Available Volumetric Water Capacity}}{
+Searle, R., Nimalka Somarathna, P. & Malone, B. (2023). Soil and
+Landscape Grid National Soil Attribute Maps - Available Volumetric
+Water Capacity (Percent) (3 arc second resolution) Version 2.
+Version 2.0. Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/4jwj-na34}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/482301c2-b9a1-4345-b142-815f9b37890a}
+}
+\item{\strong{CLY: SLGA Attribute - Clay content}}{
+Malone, B. & Searle, R. (2022). Soil and Landscape Grid National
+Soil Attribute Maps - Clay (3" resolution) - Release 2. Version 2.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/hc4s-3130}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/f95dc442-013b-4fad-b31f-91ba86fbe7f5}
+}
+\item{\strong{SND: SLGA Attribute - Sand content}}{
+Malone, B. & Searle, R. (2022). Soil and Landscape Grid National Soil
+Attribute Maps - Sand (3" resolution) - Release 2. Version 2.0.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/rjmy-pa10}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/4224ddff-5fb4-4170-b5ea-c0c500599700}
+}
+\item{\strong{SLT: SLGA Attribute - Silt content}}{
+Malone, B. & Searle, R. (2022). Soil and Landscape Grid National Soil
+Attribute Maps - Silt (3" resolution) - Release 2. Version 2.0.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/2ew1-0w57}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/11375f04-b5cd-46a7-bcac-0e83fcb58605}
+}
+\item{\strong{BDW: SLGA Attribute - Bulk Density (Whole Earth)}}{
+Malone, B. (2023). Soil and Landscape Grid National Soil Attribute
+Maps - Bulk Density - Whole Earth - Release 2. Version 2.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/gxyn-pd07}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/95978aec-6ba8-446b-a721-2b875d9f61a8}
+}
+\item{\strong{PHC: SLGA Attribute - pH (of 1:5 soil/0.01M CaCl2 extract)}}{
+Malone, B. & Searle, R. (2024). Soil and Landscape Grid National Soil
+Attribute Maps - pH - Calcium Chloride (3" resolution) - Release 2.
+Version 2. Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/7320-hw30}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/258afc98-7407-4781-b241-cb0293b4b8aa}
+}
+\item{\strong{PHW: SLGA Attribute - pH (of 1:5 soil water solution)}}{
+Malone, B. (2022). Soil and Landscape Grid National Soil Attribute
+Maps - pH (Water) (3" resolution) - Release 1. Version 1.0.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/37z2-0q10}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/c37439a5-e622-44ab-9c24-bfd632d8203c}
+}
+\item{\strong{NTO: SLGA Attribute - Total nitrogen}}{
+Malone, B. & Searle, R. (2024). Soil and Landscape Grid National Soil
+Attribute Maps - Total Nitrogen (3" resolution) - Release 2. Version 2.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/pm2n-ww12}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/e9484508-c705-4c23-9195-f26d64b9d4f1}
+}
+\item{\strong{AVP: SLGA Attribute - Available phosphorus}}{
+Zund, P. (2022). Soil and Landscape Grid National Soil Attribute Maps
+- Available Phosphorus (3" resolution) - Release 1. Version 1.0.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/6qzh-b979}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/c6ef289b-1ca8-4e53-b8b4-aa97e4706c63}
+}
+\item{\strong{PTO: SLGA Attribute - Total phosphorus}}{
+Malone, B. & Searle, R. (2024). Soil and Landscape Grid National Soil
+Attribute Maps - Total Phosphorus (3" resolution) - Release 2.
+Version 2. Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/7j78-md43}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/be382e63-5ff6-40a9-930f-c84655a5bd87}
+}
+\item{\strong{CEC: SLGA Attribute - Cation exchange capacity}}{
+Malone, B. (2024). Soil and Landscape Grid National Soil Attribute Maps
+- Cation Exchange Capacity (3" resolution) - Release 1. Version 1.0.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/pkva-gf85}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/5b4b2991-bfa6-41df-be33-7009a5d0a5b0}
+}
+\item{\strong{ECE: SLGA Attribute - Effective cation exchange capacity}}{
+Viscarra Rossel, R., Chen, C., Grundy, M., Searle, R., Clifford, D.,
+Odgers, N., Holmes, K., Griffin, T., Liddicoat, C. & Kidd, D. (2014).
+Soil and Landscape Grid National Soil Attribute Maps - Effective Cation
+Exchange Capacity (3" resolution) - Release 1. Version 1. Terrestrial
+Ecosystem Research Network. (Dataset).
+\doi{10.4225/08/546F091C11777}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/0d27cf8b-6627-4f33-8398-1b525bc1a210}
+}
+\item{\strong{DUL: SLGA Attribute - Drained upper limit volumetric water content}}{
+Searle, R. & Nimalka Somarathna, P. (2022). Soil and Landscape Grid
+National Soil Attribute Maps - Drained Upper Limit Volumetric Water
+Content (Percent) (3 arc second resolution) Version 1. Version 1.0.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/jnvd-3a26}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/de9ddc12-b8e4-4ff2-99c4-390227a848aa}
+}
+\item{\strong{L15: SLGA Attribute - 15 bar lower limit volumetric water content}}{
+Searle, R. & Nimalka Somarathna, P. (2022). Soil and Landscape Grid
+National Soil Attribute Maps - 15 Bar Lower Limit Volumetric Water
+Content (Percent) (3 arc second resolution) Version 1. Version 1.0.
+Terrestrial Ecosystem Research Network. (Dataset).
+\doi{10.25919/awp8-nv68}.\cr\cr TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/4443f5df-a0b2-4352-b44b-83f7feb1e27d}
+}
+\item{\strong{SOILDIV: Soil Bacteria and Soil Fungi Beta Diversity}}{
+Dobarco, M., Wadoux, A. & Xue, P. (2024). Soil and Landscape Grid National
+Soil Attribute Maps - Soil Bacteria and Fungi Beta Diversity (3"
+resolution) - Release 1. Version 1.0. Terrestrial Ecosystem Research
+Network. (Dataset). \doi{10.25919/4x7n-y874}.\cr\cr
+TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/4a428d52-dda6-4097-8dd9-d3ec63973029}
+}
+\item{\strong{CANOPY: OzTreeMap Best-Pick Canopy Height Model}}{
+Pucino, N., McVicar, T., Levick, S. & Albert van Dijk (2025).
+Australia-Wide 30 m Machine Learning-Derived Canopy Height Models
+Composites: Best Pick and Median. Version 1. Terrestrial Ecosystem
+Research Network. (Dataset). \doi{10.25901/xqv7-jk46}.\cr\cr
+TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/36c98155-39c8-4eec-9070-a978933f3fa3}
+}
+\item{\strong{PHENOLOGY: Australian Land Surface Phenology}}{
+Xie, Q. & Huete, A. (2024). Australian land surface phenology dataset at
+500m resolution. Version 1.0. Terrestrial Ecosystem Research Network.
+(Dataset). URL: \url{https://portal.tern.org.au/metadata/2bb0c81a-41a9-434c-b87a-db0301cb52fb}.\cr\cr
+TERN Point-of-truth metadata URL:
+\url{https://geonetwork.tern.org.au/geonetwork/srv/eng/catalog.search#/metadata/2bb0c81a-41a9-434c-b87a-db0301cb52fb}
+}
+}
 }

--- a/tests/testthat/_snaps/url-snapshots.md
+++ b/tests/testthat/_snaps/url-snapshots.md
@@ -26,7 +26,7 @@
       /vsicurl/https://apikey:test-key-0000@data.tern.org.au/model-derived/aet/v2_2/2023/2023_06_01/CMRSET_LANDSAT_V2_2_2023_06_01_ETa.vrt
       /vsicurl/https://apikey:test-key-0000@data.tern.org.au/model-derived/aet/v2_2/2023/2023_06_01/CMRSET_LANDSAT_V2_2_2023_06_01_pixel_qa.vrt
 
-# SLGA URLs are stable across all eight attributes
+# SLGA URLs are stable across all attributes
 
     Code
       cat(sink$urls, sep = "\n")
@@ -39,6 +39,12 @@
       /vsicurl/https://apikey:test-key-0000@data.tern.org.au/model-derived/slga/NationalMaps/SoilAndLandscapeGrid/pHc/v2/PHC_000_005_EV_N_P_AU_NAT_C_20210913.tif
       /vsicurl/https://apikey:test-key-0000@data.tern.org.au/model-derived/slga/NationalMaps/SoilAndLandscapeGrid/PHW/v1/PHW_000_005_EV_N_P_AU_TRN_N_20220520.tif
       /vsicurl/https://apikey:test-key-0000@data.tern.org.au/model-derived/slga/NationalMaps/SoilAndLandscapeGrid/NTO/v2/NTO_000_005_EV_N_P_AU_NAT_C_20231101.tif
+      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/model-derived/slga/NationalMaps/SoilAndLandscapeGrid/AVP/v1/AVP_000_005_EV_N_P_AU_TRN_N_20220826.tif
+      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/model-derived/slga/NationalMaps/SoilAndLandscapeGrid/PTO/v2/PTO_000_005_EV_N_P_AU_NAT_C_20231101.tif
+      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/model-derived/slga/NationalMaps/SoilAndLandscapeGrid/CEC/v1/CEC_000_005_EV_N_P_AU_TRN_N_20220826.tif
+      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/model-derived/slga/NationalMaps/SoilAndLandscapeGrid/ECE/v1/ECE_000_005_EV_N_P_AU_NAT_C_20140801.tif
+      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/model-derived/slga/NationalMaps/SoilAndLandscapeGrid/DUL/v1/DUL_000_005_EV_N_P_AU_TRN_N_20210614.tif
+      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/model-derived/slga/NationalMaps/SoilAndLandscapeGrid/L15/v1/L15_000_005_EV_N_P_AU_TRN_N_20210614.tif
 
 # SLGA URLs are stable across all six depth intervals
 
@@ -52,13 +58,14 @@
       /vsicurl/https://apikey:test-key-0000@data.tern.org.au/model-derived/slga/NationalMaps/SoilAndLandscapeGrid/AWC/v2/AWC_060_100_EV_N_P_AU_TRN_N_20210614.tif
       /vsicurl/https://apikey:test-key-0000@data.tern.org.au/model-derived/slga/NationalMaps/SoilAndLandscapeGrid/AWC/v2/AWC_100_200_EV_N_P_AU_TRN_N_20210614.tif
 
-# SLGA EV vs CI URLs are stable
+# SLGA EV vs CI (05, 95) URLs are stable
 
     Code
       cat(sink$urls, sep = "\n")
     Output
       /vsicurl/https://apikey:test-key-0000@data.tern.org.au/model-derived/slga/NationalMaps/SoilAndLandscapeGrid/AWC/v2/AWC_000_005_EV_N_P_AU_TRN_N_20210614.tif
-      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/model-derived/slga/NationalMaps/SoilAndLandscapeGrid/AWC/v2/AWC_000_005_CI_N_P_AU_TRN_N_20210614.tif
+      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/model-derived/slga/NationalMaps/SoilAndLandscapeGrid/AWC/v2/AWC_000_005_05_N_P_AU_TRN_N_20210614.tif
+      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/model-derived/slga/NationalMaps/SoilAndLandscapeGrid/AWC/v2/AWC_000_005_95_N_P_AU_TRN_N_20210614.tif
 
 # Soil Beta Diversity URLs are stable across collections and axes
 

--- a/tests/testthat/_snaps/url-snapshots.md
+++ b/tests/testthat/_snaps/url-snapshots.md
@@ -86,7 +86,7 @@
     Output
       /vsicurl/https://apikey:test-key-0000@data.tern.org.au/model-derived/OzTreeMap/CanopyHeightComposite/best_pick_files_bhLNnun.tif
 
-# Phenology URLs are stable across all ten metrics
+# Phenology URLs are stable across all eight metrics
 
     Code
       cat(sink$urls, sep = "\n")
@@ -95,12 +95,10 @@
       /vsicurl/https://apikey:test-key-0000@data.tern.org.au/remote-sensing/modis/phenology_myd13a1/2_Peak_of_the_growing_season/PGS_2018_Season1.tif
       /vsicurl/https://apikey:test-key-0000@data.tern.org.au/remote-sensing/modis/phenology_myd13a1/3_End_of_the_growing_season/EGS_2018_Season1.tif
       /vsicurl/https://apikey:test-key-0000@data.tern.org.au/remote-sensing/modis/phenology_myd13a1/4_Length_of_the_growing_season/LGS_2018_Season1.tif
-      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/remote-sensing/modis/phenology_myd13a1/5_Start_of_season/SOS_2018_Season1.tif
-      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/remote-sensing/modis/phenology_myd13a1/6_Peak_of_season/POS_2018_Season1.tif
-      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/remote-sensing/modis/phenology_myd13a1/7_End_of_season/EOS_2018_Season1.tif
-      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/remote-sensing/modis/phenology_myd13a1/8_Length_of_season/LOS_2018_Season1.tif
-      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/remote-sensing/modis/phenology_myd13a1/9_Rate_of_greening/ROG_2018_Season1.tif
-      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/remote-sensing/modis/phenology_myd13a1/10_Rate_of_senescence/ROS_2018_Season1.tif
+      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/remote-sensing/modis/phenology_myd13a1/5_Minimum_EVI_value_before_PGS/EVI1_2018_Season1.tif
+      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/remote-sensing/modis/phenology_myd13a1/6_Minimum_EVI_value_after_PGS/EVI2_2018_Season1.tif
+      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/remote-sensing/modis/phenology_myd13a1/7_Peak_EVI_value_of_the_growing_season/EVIP_2018_Season1.tif
+      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/remote-sensing/modis/phenology_myd13a1/8_Integral_EVI_value_of_the_growing_season/EVII_2018_Season1.tif
 
 # Phenology URLs are stable across seasons and years
 

--- a/tests/testthat/_snaps/url-snapshots.md
+++ b/tests/testthat/_snaps/url-snapshots.md
@@ -86,7 +86,7 @@
     Output
       /vsicurl/https://apikey:test-key-0000@data.tern.org.au/model-derived/OzTreeMap/CanopyHeightComposite/best_pick_files_bhLNnun.tif
 
-# Phenology URLs are stable across all eight metrics
+# Phenology URLs are stable across all eleven metrics
 
     Code
       cat(sink$urls, sep = "\n")
@@ -99,6 +99,9 @@
       /vsicurl/https://apikey:test-key-0000@data.tern.org.au/remote-sensing/modis/phenology_myd13a1/6_Minimum_EVI_value_after_PGS/EVI2_2018_Season1.tif
       /vsicurl/https://apikey:test-key-0000@data.tern.org.au/remote-sensing/modis/phenology_myd13a1/7_Peak_EVI_value_of_the_growing_season/EVIP_2018_Season1.tif
       /vsicurl/https://apikey:test-key-0000@data.tern.org.au/remote-sensing/modis/phenology_myd13a1/8_Integral_EVI_value_of_the_growing_season/EVII_2018_Season1.tif
+      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/remote-sensing/modis/phenology_myd13a1/9_Start_of_the_growing_season_by_month/SGS_2018_Season1.tif
+      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/remote-sensing/modis/phenology_myd13a1/10_Peak_of_the_growing_season_by_month/PGS_2018_Season1.tif
+      /vsicurl/https://apikey:test-key-0000@data.tern.org.au/remote-sensing/modis/phenology_myd13a1/11_End_of_the_growing_season_by_month/EGS_2018_Season1.tif
 
 # Phenology URLs are stable across seasons and years
 

--- a/tests/testthat/test-.check_aet_date.R
+++ b/tests/testthat/test-.check_aet_date.R
@@ -7,19 +7,19 @@ test_that("Date is snapped to first of month", {
   expect_identical(format(date_checked, "%Y-%m-%d"), "2023-06-01")
 })
 
-test_that("Dates before 2000-02-01 throw an error", {
+test_that("Dates before 1987-05-01 throw an error", {
   expect_error(
-    .check_aet_date("2000-01-01"),
-    "AET data are not available before 2000-02-01"
+    .check_aet_date("1980-01-01"),
+    "AET data are not available before 1987-05-01"
   )
   expect_error(
-    .check_aet_date("1999-12-01"),
-    "AET data are not available before 2000-02-01"
+    .check_aet_date("1960-12-20"),
+    "AET data are not available before 1987-05-01"
   )
 })
 
-test_that("Dates on or after 2000-02-01 are accepted", {
-  expect_no_error(.check_aet_date("2000-02-01"))
+test_that("Dates on or after 1987-05-01 are accepted", {
+  expect_no_error(.check_aet_date("1987-05-01"))
   expect_no_error(.check_aet_date("2023-06-15"))
 })
 

--- a/tests/testthat/test-.check_collection_agreement.R
+++ b/tests/testthat/test-.check_collection_agreement.R
@@ -5,6 +5,38 @@ test_that("A valid SMIPS date passes the bounds check", {
   expect_null(.check_collection_agreement("totalbucket", as.Date("2015-11-20")))
 })
 
+# Adding some tests to check that dates work in any format.
+# Russell (07/06): Note that we're hard-coding an assumption here that
+#   different timezones don't matter (e.g., see Issue #47): someone asking
+#   for the 2026-02-01 dataset should expect to get the 2026-02-01 dataset
+#   (in 'Australia time'). I think this is a safe assumption for most use cases.
+test_that("The .day argument is checked consistently across various types", {
+  expect_error(
+    .check_collection_agreement("totalbucket", "2000-01-01"),
+    "You requested 2000-01-01"
+  )
+  expect_error(
+    .check_collection_agreement("totalbucket", as.Date("2000-01-01")),
+    "You requested 2000-01-01"
+  )
+  expect_error(
+    .check_collection_agreement("totalbucket", as.POSIXct("2000-01-01")),
+    "You requested 2000-01-01"
+  )
+  expect_error(
+    .check_collection_agreement("totalbucket", as.POSIXct("2000-01-01", tz = "UTC")),
+    "You requested 2000-01-01"
+  )
+  expect_error(
+    .check_collection_agreement("totalbucket", as.POSIXct("2000-01-01", tz = "ACST")),
+    "You requested 2000-01-01"
+  )
+  expect_error(
+    .check_collection_agreement("totalbucket", as.POSIXct("2000-01-01", tz = "EST")),
+    "You requested 2000-01-01"
+  )
+})
+
 test_that("Dates before 2015-01-01 are rejected", {
   expect_error(
     .check_collection_agreement("totalbucket", as.Date("2014-07-19")),
@@ -16,14 +48,21 @@ test_that("Dates before 2015-01-01 are rejected", {
   )
 })
 
+test_that("The 2015-01-01 date is passed successfully", {
+  expect_null(.check_collection_agreement("totalbucket", as.Date("2015-01-01")))
+})
 
-#FIXME: Russell (01/06) We can fix/remove this test, it's nonsensical
-#  given that there is no "seven-day publication delay" at all. (And while
-#  I'm here, I feel like putting these tests inside a 'test-read_smips.R'
-#  file is probably a nicer way to do this...)
-test_that("Dates within the seven-day publication delay are rejected", {
+test_that("Dates beyond today's date are rejected", {
   expect_error(
-    .check_collection_agreement("totalbucket", lubridate::today()),
-    "publishes with a roughly seven-day delay"
+    .check_collection_agreement(
+      "totalbucket", lubridate::today() + lubridate::days(3)
+    ),
+    "not yet available"
+  )
+  expect_error(
+    .check_collection_agreement(
+      "totalbucket", lubridate::today() + lubridate::years(2)
+    ),
+    "not yet available"
   )
 })

--- a/tests/testthat/test-.check_collection_agreement.R
+++ b/tests/testthat/test-.check_collection_agreement.R
@@ -5,17 +5,22 @@ test_that("A valid SMIPS date passes the bounds check", {
   expect_null(.check_collection_agreement("totalbucket", as.Date("2015-11-20")))
 })
 
-test_that("Dates before 2015-11-20 are rejected", {
+test_that("Dates before 2015-01-01 are rejected", {
   expect_error(
-    .check_collection_agreement("totalbucket", as.Date("2015-11-19")),
-    "not available before 2015-11-20"
+    .check_collection_agreement("totalbucket", as.Date("2014-07-19")),
+    "not generally available before 2015-01-01"
   )
   expect_error(
     .check_collection_agreement("SMindex", as.Date("2004-01-01")),
-    "not available before 2015-11-20"
+    "not generally available before 2015-01-01"
   )
 })
 
+
+#FIXME: Russell (01/06) We can fix/remove this test, it's nonsensical
+#  given that there is no "seven-day publication delay" at all. (And while
+#  I'm here, I feel like putting these tests inside a 'test-read_smips.R'
+#  file is probably a nicer way to do this...)
 test_that("Dates within the seven-day publication delay are rejected", {
   expect_error(
     .check_collection_agreement("totalbucket", lubridate::today()),

--- a/tests/testthat/test-collect_tern_data.R
+++ b/tests/testthat/test-collect_tern_data.R
@@ -87,7 +87,7 @@ test_that(".parse_date_range rejects unparseable dates", {
 # .normalise_datasets -------------------------------------------------------
 
 test_that(".normalise_datasets returns the full alias set for NULL/'all'", {
-  expect_identical(length(.normalise_datasets(NULL)), 14L)
+  expect_identical(length(.normalise_datasets(NULL)), 20L)
   expect_identical(.normalise_datasets("all"), .normalise_datasets(NULL))
 })
 

--- a/tests/testthat/test-read_aet.R
+++ b/tests/testthat/test-read_aet.R
@@ -47,21 +47,21 @@ test_that("read_aet errors when date is missing", {
   expect_error(read_aet(), "argument \"date\" is missing")
 })
 
-test_that("read_aet errors for dates before 2000-02-01", {
+test_that("read_aet errors for dates before 1987-05-01", {
   expect_error(
-    read_aet("1999-06-01", api_key = KEY),
-    "AET data are not available before 2000"
+    read_aet("1979-06-01", api_key = KEY),
+    "AET data are not available before 1987"
   )
   expect_error(
-    read_aet("2000-01-31", api_key = KEY),
-    "AET data are not available before 2000"
+    read_aet("1987-04-30", api_key = KEY),
+    "AET data are not available before 1987"
   )
 })
 
-test_that("read_aet accepts the earliest available date (2000-02-01)", {
+test_that("read_aet accepts the earliest available date (1987-05-01)", {
   sink <- .use_mocked_cog()
-  read_aet("2000-02-01", api_key = KEY)
-  expect_match(sink$urls, "2000_02_01_ETa.vrt$")
+  read_aet("1987-05-01", api_key = KEY)
+  expect_match(sink$urls, "1987_05_01_ETa.vrt$")
 })
 
 test_that("read_aet rejects an unknown collection at .make_aet_url", {

--- a/tests/testthat/test-read_asc.R
+++ b/tests/testthat/test-read_asc.R
@@ -15,7 +15,7 @@ test_that("read_asc returns the confusion index for soil class", {
   skip_on_cran()
   skip_on_ci()
   skip_if(!nzchar(Sys.getenv("TERN_API_KEY")), "TERN API key not available")
-  asc <- read_asc(confusion_index = TRUE)
+  asc <- read_asc(collection = "CI")
   expect_named(asc, "ASC_CI_C_P_AU_TRN_N.cog")
 })
 
@@ -33,9 +33,9 @@ test_that("read_asc() default builds the EV URL", {
   )
 })
 
-test_that("read_asc(confusion_index = TRUE) builds the CI URL", {
+test_that("read_asc(collection = \"CI\") builds the CI URL", {
   sink <- .use_mocked_cog()
-  read_asc(confusion_index = TRUE, api_key = KEY)
+  read_asc(collection = "CI", api_key = KEY)
   expect_match(sink$urls, "ASC_CI_C_P_AU_TRN_N.cog.tif", fixed = TRUE)
 })
 

--- a/tests/testthat/test-read_asc.R
+++ b/tests/testthat/test-read_asc.R
@@ -2,7 +2,7 @@ KEY <- "test-key-0000"
 
 # ---- Network integration tests (skipped without API key) -------------------
 
-test_that("get_asc returns the soil classification data", {
+test_that("read_asc returns the soil classification data", {
   skip_on_cran()
   skip_on_ci()
   skip_if(!nzchar(Sys.getenv("TERN_API_KEY")), "TERN API key not available")
@@ -11,7 +11,7 @@ test_that("get_asc returns the soil classification data", {
 })
 
 
-test_that("get_smips returns the confusion index for soil class", {
+test_that("read_asc returns the confusion index for soil class", {
   skip_on_cran()
   skip_on_ci()
   skip_if(!nzchar(Sys.getenv("TERN_API_KEY")), "TERN API key not available")

--- a/tests/testthat/test-read_phenology.R
+++ b/tests/testthat/test-read_phenology.R
@@ -10,13 +10,18 @@ METRIC_DIR <- list(
   PGS = "2_Peak_of_the_growing_season",
   EGS = "3_End_of_the_growing_season",
   LGS = "4_Length_of_the_growing_season",
-  SOS = "5_Start_of_season",
-  POS = "6_Peak_of_season",
-  EOS = "7_End_of_season",
-  LOS = "8_Length_of_season",
-  ROG = "9_Rate_of_greening",
-  ROS = "10_Rate_of_senescence"
+  EVI1 = "5_Minimum_EVI_value_before_PGS",
+  EVI2 = "6_Minimum_EVI_value_after_PGS",
+  EVIP = "7_Peak_EVI_value_of_the_growing_season",
+  EVII = "8_Integral_EVI_value_of_the_growing_season"
 )
+#FIXME: Russell (02/06): This is an inadequate test fixture (and it's why
+#  we didn't catch the hallucinated variables ala Issue #44). We need these
+#  to actually match with what TERN's directories are on their server. As
+#  noble as the idea of "No network I/O" is, I reckon we need at least a
+#  single request here just to verify that the directories are what the
+#  package expects them to be (and so the testing can flag if they are
+#  ever changed on the remote server too).
 
 # ---- All ten metrics map to the documented subdirectory --------------------
 

--- a/tests/testthat/test-read_phenology.R
+++ b/tests/testthat/test-read_phenology.R
@@ -13,7 +13,10 @@ METRIC_DIR <- list(
   EVI1 = "5_Minimum_EVI_value_before_PGS",
   EVI2 = "6_Minimum_EVI_value_after_PGS",
   EVIP = "7_Peak_EVI_value_of_the_growing_season",
-  EVII = "8_Integral_EVI_value_of_the_growing_season"
+  EVII = "8_Integral_EVI_value_of_the_growing_season",
+  SGS_month = "9_Start_of_the_growing_season_by_month",
+  PGS_month = "10_Peak_of_the_growing_season_by_month",
+  EGS_month = "11_End_of_the_growing_season_by_month"
 )
 #FIXME: Russell (02/06): This is an inadequate test fixture (and it's why
 #  we didn't catch the hallucinated variables ala Issue #44). We need these
@@ -23,8 +26,6 @@ METRIC_DIR <- list(
 #  package expects them to be (and so the testing can flag if they are
 #  ever changed on the remote server too).
 
-# ---- All ten metrics map to the documented subdirectory --------------------
-
 test_that("every phenology metric maps to its documented subdirectory", {
   sink <- .use_mocked_cog()
   for (m in names(METRIC_DIR)) {
@@ -32,8 +33,9 @@ test_that("every phenology metric maps to its documented subdirectory", {
   }
   expect_length(sink$urls, length(METRIC_DIR))
   for (i in seq_along(METRIC_DIR)) {
-    m   <- names(METRIC_DIR)[[i]]
+    m <- names(METRIC_DIR)[[i]]
     dir <- METRIC_DIR[[m]]
+    m <- sub("_month", "", m, fixed = TRUE)
     expect_match(
       sink$urls[[i]],
       sprintf("/phenology_myd13a1/%s/%s_2018_Season1.tif", dir, m),

--- a/tests/testthat/test-read_slga.R
+++ b/tests/testthat/test-read_slga.R
@@ -3,15 +3,19 @@
 
 KEY <- "test-key-0000"
 
-# ---- All eight attributes resolve to a unique, well-formed URL -------------
+# ---- All attributes resolve to a unique, well-formed URL -------------
 
 test_that("each SLGA attribute resolves to a unique URL", {
   sink <- .use_mocked_cog()
-  for (attr in c("AWC", "CLY", "SND", "SLT", "BDW", "PHC", "PHW", "NTO")) {
+  attrs <- c(
+    "AWC", "CLY", "SND", "SLT", "BDW", "PHC", "PHW", "NTO", "AVP", "PTO",
+    "CEC", "ECE", "DUL", "L15"
+  )
+  for (attr in attrs) {
     read_slga(attr, api_key = KEY)
   }
-  expect_length(sink$urls, 8L)
-  expect_length(unique(sink$urls), 8L)
+  expect_length(sink$urls, 14L)
+  expect_length(unique(sink$urls), 14L)
 })
 
 test_that("AWC URL contains the documented prefix/version/date", {
@@ -43,6 +47,76 @@ test_that("PHW URL uses v1 / 20220520 release", {
                fixed = TRUE)
 })
 
+test_that("CLY URL uses v2 / 20210902 release", {
+  sink <- .use_mocked_cog()
+  read_slga("CLY", api_key = KEY)
+  expect_match(sink$urls, "/CLY/v2/CLY_000_005_EV_N_P_AU_TRN_N_20210902.tif",
+               fixed = TRUE)
+})
+
+test_that("SND URL uses v2 / 20210902 release", {
+  sink <- .use_mocked_cog()
+  read_slga("SND", api_key = KEY)
+  expect_match(sink$urls, "/SND/v2/SND_000_005_EV_N_P_AU_TRN_N_20210902.tif",
+               fixed = TRUE)
+})
+
+test_that("SLT URL uses v2 / 20210902 release", {
+  sink <- .use_mocked_cog()
+  read_slga("SLT", api_key = KEY)
+  expect_match(sink$urls, "/SLT/v2/SLT_000_005_EV_N_P_AU_TRN_N_20210902.tif",
+               fixed = TRUE)
+})
+
+test_that("BDW URL uses v2 / 20230607 release", {
+  sink <- .use_mocked_cog()
+  read_slga("BDW", api_key = KEY)
+  expect_match(sink$urls, "/BDW/v2/BDW_000_005_EV_N_P_AU_TRN_N_20230607.tif",
+               fixed = TRUE)
+})
+
+test_that("AVP URL uses v1 / 20220826 release", {
+  sink <- .use_mocked_cog()
+  read_slga("AVP", api_key = KEY)
+  expect_match(sink$urls, "/AVP/v1/AVP_000_005_EV_N_P_AU_TRN_N_20220826.tif",
+               fixed = TRUE)
+})
+
+test_that("PTO URL uses v2 / 20231101 release", {
+  sink <- .use_mocked_cog()
+  read_slga("PTO", api_key = KEY)
+  expect_match(sink$urls, "/PTO/v2/PTO_000_005_EV_N_P_AU_NAT_C_20231101.tif",
+               fixed = TRUE)
+})
+
+test_that("CEC URL uses v1 / 20220826 release", {
+  sink <- .use_mocked_cog()
+  read_slga("CEC", api_key = KEY)
+  expect_match(sink$urls, "/CEC/v1/CEC_000_005_EV_N_P_AU_TRN_N_20220826.tif",
+               fixed = TRUE)
+})
+
+test_that("ECE URL uses v1 / 20140801 release", {
+  sink <- .use_mocked_cog()
+  read_slga("ECE", api_key = KEY)
+  expect_match(sink$urls, "/ECE/v1/ECE_000_005_EV_N_P_AU_NAT_C_20140801.tif",
+               fixed = TRUE)
+})
+
+test_that("DUL URL uses v1 / 20210614 release", {
+  sink <- .use_mocked_cog()
+  read_slga("DUL", api_key = KEY)
+  expect_match(sink$urls, "/DUL/v1/DUL_000_005_EV_N_P_AU_TRN_N_20210614.tif",
+               fixed = TRUE)
+})
+
+test_that("L15 URL uses v1 / 20210614 release", {
+  sink <- .use_mocked_cog()
+  read_slga("L15", api_key = KEY)
+  expect_match(sink$urls, "/L15/v1/L15_000_005_EV_N_P_AU_TRN_N_20210614.tif",
+               fixed = TRUE)
+})
+
 # ---- Depth selector --------------------------------------------------------
 
 test_that("depth selector flows through to the filename", {
@@ -63,22 +137,25 @@ test_that("read_slga rejects an unknown depth", {
                "must be one of")
 })
 
-# ---- Collection (EV / CI) selector ----------------------------------------
-
-test_that("collection switches between EV and CI in the filename", {
+# Russell (08/06): Another inadequate test: we need these to actually
+#   correspond to reality in the mocking. Prior to my change below it
+#   was checking for a "CI" dataset that doesn't exist on the TERN
+#   server, so the unit tests thought everything was fine even when
+#   read_slga() couldn't return the confidence interval rasters.
+test_that("collection switches between EV, 05, 95 in the filename", {
   sink <- .use_mocked_cog()
   read_slga("AWC", collection = "EV", api_key = KEY)
-  read_slga("AWC", collection = "CI", api_key = KEY)
+  read_slga("AWC", collection = "05", api_key = KEY)
+  read_slga("AWC", collection = "95", api_key = KEY)
   expect_match(sink$urls[[1L]], "_EV_N_P_", fixed = TRUE)
-  expect_match(sink$urls[[2L]], "_CI_N_P_", fixed = TRUE)
+  expect_match(sink$urls[[2L]], "_05_N_P_", fixed = TRUE)
+  expect_match(sink$urls[[3L]], "_95_N_P_", fixed = TRUE)
 })
 
 test_that("read_slga rejects an unknown collection", {
   expect_error(read_slga("AWC", collection = "XX", api_key = KEY),
                "must be one of")
 })
-
-# ---- Attribute validation --------------------------------------------------
 
 test_that("read_slga rejects an unsupported attribute", {
   expect_error(read_slga("ZZZ", api_key = KEY), "must be one of")

--- a/tests/testthat/test-read_tern.R
+++ b/tests/testthat/test-read_tern.R
@@ -70,15 +70,15 @@ test_that("read_tern AET errors when date is missing", {
 test_that("read_tern AET accepts legacy 'month' arg name", {
   # Should reach .check_aet_date, not the missing-date guard
   expect_error(
-    read_tern("TERN/9fefa68b", month = "1999-01-01"),
-    "AET data are not available before 2000"
+    read_tern("TERN/9fefa68b", month = "1980-01-01"),
+    "AET data are not available before 1987"
   )
 })
 
-test_that("read_tern AET errors for date before 2000-02-01", {
+test_that("read_tern AET errors for date before 1987-05-01", {
   expect_error(
-    read_tern("TERN/9fefa68b", date = "2000-01-01"),
-    "AET data are not available before 2000"
+    read_tern("TERN/9fefa68b", date = "1987-04-15"),
+    "AET data are not available before 1987"
   )
 })
 

--- a/tests/testthat/test-url-snapshots.R
+++ b/tests/testthat/test-url-snapshots.R
@@ -95,9 +95,9 @@ test_that("Canopy Height URL is stable", {
 
 # ---- Phenology -------------------------------------------------------------
 
-test_that("Phenology URLs are stable across all eight metrics", {
+test_that("Phenology URLs are stable across all eleven metrics", {
   sink <- .use_mocked_cog()
-  for (m in c("SGS", "PGS", "EGS", "LGS", "EVI1", "EVI2", "EVIP", "EVII")) {
+  for (m in c("SGS", "PGS", "EGS", "LGS", "EVI1", "EVI2", "EVIP", "EVII", "SGS_month", "PGS_month", "EGS_month")) {
     read_phenology(year = 2018L, season = 1L, collection = m, api_key = KEY)
   }
   expect_snapshot(cat(sink$urls, sep = "\n"))

--- a/tests/testthat/test-url-snapshots.R
+++ b/tests/testthat/test-url-snapshots.R
@@ -28,8 +28,8 @@ test_that("SMIPS URLs are stable across all six collections", {
 
 test_that("ASC URLs are stable for EV and CI", {
   sink <- .use_mocked_cog()
-  read_asc(confusion_index = FALSE, api_key = KEY)
-  read_asc(confusion_index = TRUE,  api_key = KEY)
+  read_asc(collection = "EV", api_key = KEY)
+  read_asc(collection = "CI", api_key = KEY)
   expect_snapshot(cat(sink$urls, sep = "\n"))
 })
 

--- a/tests/testthat/test-url-snapshots.R
+++ b/tests/testthat/test-url-snapshots.R
@@ -90,10 +90,9 @@ test_that("Canopy Height URL is stable", {
 
 # ---- Phenology -------------------------------------------------------------
 
-test_that("Phenology URLs are stable across all ten metrics", {
+test_that("Phenology URLs are stable across all eight metrics", {
   sink <- .use_mocked_cog()
-  for (m in c("SGS", "PGS", "EGS", "LGS", "SOS",
-              "POS", "EOS", "LOS", "ROG", "ROS")) {
+  for (m in c("SGS", "PGS", "EGS", "LGS", "EVI1", "EVI2", "EVIP", "EVII")) {
     read_phenology(year = 2018L, season = 1L, collection = m, api_key = KEY)
   }
   expect_snapshot(cat(sink$urls, sep = "\n"))

--- a/tests/testthat/test-url-snapshots.R
+++ b/tests/testthat/test-url-snapshots.R
@@ -42,11 +42,15 @@ test_that("AET URLs are stable for ETa and pixel_qa", {
   expect_snapshot(cat(sink$urls, sep = "\n"))
 })
 
-# ---- SLGA (all eight attributes, default depth 000_005, stat EV) ------------
+# ---- SLGA (all attributes, default depth 000_005, stat EV) ------------
 
-test_that("SLGA URLs are stable across all eight attributes", {
+test_that("SLGA URLs are stable across all attributes", {
   sink <- .use_mocked_cog()
-  for (attr in c("AWC", "CLY", "SND", "SLT", "BDW", "PHC", "PHW", "NTO")) {
+  attrs <- c(
+    "AWC", "CLY", "SND", "SLT", "BDW", "PHC", "PHW", "NTO", "AVP", "PTO",
+    "CEC", "ECE", "DUL", "L15"
+  )
+  for (attr in attrs) {
     read_slga(attr, api_key = KEY)
   }
   expect_snapshot(cat(sink$urls, sep = "\n"))
@@ -61,10 +65,11 @@ test_that("SLGA URLs are stable across all six depth intervals", {
   expect_snapshot(cat(sink$urls, sep = "\n"))
 })
 
-test_that("SLGA EV vs CI URLs are stable", {
+test_that("SLGA EV vs CI (05, 95) URLs are stable", {
   sink <- .use_mocked_cog()
   read_slga("AWC", collection = "EV", api_key = KEY)
-  read_slga("AWC", collection = "CI", api_key = KEY)
+  read_slga("AWC", collection = "05", api_key = KEY)
+  read_slga("AWC", collection = "95", api_key = KEY)
   expect_snapshot(cat(sink$urls, sep = "\n"))
 })
 

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -27,14 +27,20 @@ test_that(".read_cog rejects negative initial_delay", {
 
 # read_asc -- confusion_index strict logical ---------------------------------
 
-test_that("read_asc rejects non-logical confusion_index", {
-  expect_error(read_asc(confusion_index = NULL), "single non-NA logical")
-  expect_error(read_asc(confusion_index = NA), "single non-NA logical")
-  expect_error(read_asc(confusion_index = "TRUE"), "single non-NA logical")
-  expect_error(read_asc(confusion_index = c(TRUE, FALSE)),
-               "single non-NA logical")
-  expect_error(read_asc(confusion_index = 1L), "single non-NA logical")
-})
+#FIXME: Russell (04/06): Since we've changed the interface to be
+#  collection-based, this test for non-logical confusion_index no longer
+#  makes sense. Presumably we should replace it with one that tests that
+#  the collection choice is valid, but we want those sorts of tests for
+#  every one of the read_* functions actually.
+
+# test_that("read_asc rejects non-logical confusion_index", {
+#   expect_error(read_asc(confusion_index = NULL), "single non-NA logical")
+#   expect_error(read_asc(confusion_index = NA), "single non-NA logical")
+#   expect_error(read_asc(confusion_index = "TRUE"), "single non-NA logical")
+#   expect_error(read_asc(confusion_index = c(TRUE, FALSE)),
+#                "single non-NA logical")
+#   expect_error(read_asc(confusion_index = 1L), "single non-NA logical")
+# })
 
 # .tern_dispatch_id -- vector inputs -----------------------------------------
 

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -25,23 +25,6 @@ test_that(".read_cog rejects negative initial_delay", {
   )
 })
 
-# read_asc -- confusion_index strict logical ---------------------------------
-
-#FIXME: Russell (04/06): Since we've changed the interface to be
-#  collection-based, this test for non-logical confusion_index no longer
-#  makes sense. Presumably we should replace it with one that tests that
-#  the collection choice is valid, but we want those sorts of tests for
-#  every one of the read_* functions actually.
-
-# test_that("read_asc rejects non-logical confusion_index", {
-#   expect_error(read_asc(confusion_index = NULL), "single non-NA logical")
-#   expect_error(read_asc(confusion_index = NA), "single non-NA logical")
-#   expect_error(read_asc(confusion_index = "TRUE"), "single non-NA logical")
-#   expect_error(read_asc(confusion_index = c(TRUE, FALSE)),
-#                "single non-NA logical")
-#   expect_error(read_asc(confusion_index = 1L), "single non-NA logical")
-# })
-
 # .tern_dispatch_id -- vector inputs -----------------------------------------
 
 test_that(".tern_dispatch_id rejects vector input", {


### PR DESCRIPTION
Here's the code review (as well as a bunch of bug fixes and documentation updates). It looks big, but most of it is fixing up the documentation and adding the references from the dataset doc.

### For brevity, the main items were...

- `read_smips()`: fixed up the variable descriptions so that they matched reality, and fixed the date check issue where the POSIXct conversion was checking the previous date rather than the date requested.
- `read_phenology()`: removed the Claude-hallucinated variables (over half the dataset...!) and replaced them with variables that actually exist.
- `read_asc()`: Changed the interface so that it matches with the rest of the `read_*` functions. **(As such, the test in `test-validation.R` no longer makes sense, so I've tentatively commented it out, which is what the linter is complaining about in the CI.)**
- `read_slga()`: added an additional 6 datasets and fixed up the interface so that the confidence interval limits can actually be retrieved now.
- `read_tern()`: fixed up the dataset IDs for the SLGA variables.
- `DESCRIPTION` and `LICENSE`/`LICENSE.md`: Updated the copyright holder info. @adamhsparks please double-check this one; I removed an explicit line that had Curtin Uni listed as a copyright holder/providing support in favour of just having the GRDC listed as the copyright holder based on cognate discussions we were having with the WOP crew. I'm not wedded to the decision though, so let me know if you want Curtin listed in the `DESCRIPTION` file and we can add it back. (We can probably add Adelaide Uni too in such a case.)
- `collect_tern_data()`: I've barely changed this one except to add the new SLGA datasets. @max578 I've made a note in here that the data aggregation may not work as expected with the canopy height dataset, which comes in a EPSG:3577 coordinate raster rather than the WGS84 ones. Can you investigate and double-check that things are working with this aggregator function the way you expect them to?

This PR fixes the showstopper bugs we recently discovered in the issue tracker, as well as fixes up the documentation so it isn't embarrassing. Assuming that I haven't overlooked anything too bad, I reckon we're mostly good to go for the package finalisation ahead of the submission.

### I haven't worried about the test suite too much (yet)
I've made minor updates to the tests, but ideally the entire test suite would be re-examined separately. We know for a fact that it isn't exhaustive and testing everything we need it to (e.g., because it didn't pick up on the fact that half of the phenology variables were made up, nor did it pick up on the fact that the SLGA confidence intervals were unobtainable because Claude hallucinated how to retrieve them). 

Also, as I can attest from this deep dive, the number of tests seems inflated: _semantically-identical_ tests appear all over the place, e.g., the date extents for AET are tested in `test-.check_aet_date.R`, and again in `test-read_aet.R`, and then again in `test-read_tern.R`. That is, there are (at least) three tests checking whether `.check_aet_date()` handles the date validation correctly, because the other two tests are just checking it again via the function delegation. It's worth building the test suite out a little more I reckon, but that can be an in-progress task as the project continues.