### PR TITLE
style: add explicit return statements to functions

### DIFF
--- a/R/collect_tern_data.R
+++ b/R/collect_tern_data.R
@@ -179,7 +179,7 @@ collect_tern_data <- function(
     )
   }
 
-  out[]
+  return(out[])
 }
 
 
@@ -241,7 +241,7 @@ collect_tern_data <- function(
       "Coordinate out of bounds: lon in [-180, 180], lat in [-90, 90]."
     )
   }
-  coords
+  return(coords)
 }
 
 
@@ -255,7 +255,9 @@ collect_tern_data <- function(
 #' @autoglobal
 #' @dev
 .parse_date_range <- function(date_range) {
-  bad <- function() cli::cli_abort("No valid dates in {.arg date_range}.")
+  bad <- function() {
+    return(cli::cli_abort("No valid dates in {.arg date_range}."))
+  }
   dates <- tryCatch({
     if (length(date_range) == 2L && !inherits(date_range, "Date")) {
       seq(
@@ -268,7 +270,7 @@ collect_tern_data <- function(
     }
   }, error = function(e) bad())
   if (length(dates) == 0L || any(is.na(dates))) bad()
-  dates
+  return(dates)
 }
 
 #' Resolve the `datasets` argument to a clean alias vector
@@ -305,7 +307,7 @@ collect_tern_data <- function(
   if (length(datasets) == 0L) {
     cli::cli_abort("No supported datasets remained after filtering.")
   }
-  datasets
+  return(datasets)
 }
 
 
@@ -416,7 +418,7 @@ collect_tern_data <- function(
     }
   }
 
-  items
+  return(items)
 }
 
 
@@ -490,7 +492,7 @@ collect_tern_data <- function(
     out[seq.int(row_start, row_end), (wi$cols[1L]) := v]
   }
 
-  invisible(NULL)
+  return(invisible(NULL))
 }
 
 
@@ -606,5 +608,5 @@ collect_tern_data <- function(
   print(tbl, nrows = Inf)
   cat("\n")
 
-  invisible(NULL)
+  return(invisible(NULL))
 }

--- a/R/read_aet.R
+++ b/R/read_aet.R
@@ -68,14 +68,14 @@ read_aet <- function(
   max_tries = NULL,
   initial_delay = NULL
 ) {
-  read_tern(
+  return(read_tern(
     "AET",
     date = date,
     collection = collection,
     api_key = api_key,
     max_tries = max_tries,
     initial_delay = initial_delay
-  )
+  ))
 }
 
 
@@ -111,7 +111,7 @@ read_aet <- function(
     .month = month,
     .api_key = api_key
   )
-  .read_cog(full_url, max_tries, initial_delay)
+  return(.read_cog(full_url, max_tries, initial_delay))
 }
 
 
@@ -156,12 +156,12 @@ read_aet <- function(
   year <- lubridate::year(.month)
   date_str <- format(.month, "%Y_%m_%d")
 
-  sprintf(
+  return(sprintf(
     "/vsicurl/https://apikey:%s@data.tern.org.au/model-derived/aet/v2_2/%s/%s/CMRSET_LANDSAT_V2_2_%s_%s.vrt",
     .api_key,
     year,
     date_str,
     date_str,
     collection
-  )
+  ))
 }

--- a/R/read_asc.R
+++ b/R/read_asc.R
@@ -67,13 +67,13 @@ read_asc <- function(
   max_tries = NULL,
   initial_delay = NULL
 ) {
-  read_tern(
+  return(read_tern(
     "ASC",
     collection = collection,
     api_key = api_key,
     max_tries = max_tries,
     initial_delay = initial_delay
-  )
+  ))
 }
 
 
@@ -100,5 +100,5 @@ read_asc <- function(
     api_key,
     dl_file
   )
-  .read_cog(full_url, max_tries, initial_delay)
+  return(.read_cog(full_url, max_tries, initial_delay))
 }

--- a/R/read_canopy_height.R
+++ b/R/read_canopy_height.R
@@ -48,12 +48,12 @@ read_canopy_height <- function(
   max_tries = NULL,
   initial_delay = NULL
 ) {
-  read_tern(
+  return(read_tern(
     "CANOPY",
     api_key = api_key,
     max_tries = max_tries,
     initial_delay = initial_delay
-  )
+  ))
 }
 
 
@@ -68,5 +68,5 @@ read_canopy_height <- function(
     "/vsicurl/https://apikey:%s@data.tern.org.au/model-derived/OzTreeMap/CanopyHeightComposite/best_pick_files_bhLNnun.tif",
     api_key
   )
-  .read_cog(full_url, max_tries, initial_delay)
+  return(.read_cog(full_url, max_tries, initial_delay))
 }

--- a/R/read_phenology.R
+++ b/R/read_phenology.R
@@ -101,7 +101,7 @@ read_phenology <- function(
   max_tries = NULL,
   initial_delay = NULL
 ) {
-  read_tern(
+  return(read_tern(
     "PHENOLOGY",
     year = year,
     season = season,
@@ -109,7 +109,7 @@ read_phenology <- function(
     api_key = api_key,
     max_tries = max_tries,
     initial_delay = initial_delay
-  )
+  ))
 }
 
 
@@ -177,5 +177,5 @@ read_phenology <- function(
     "/vsicurl/https://apikey:%s@data.tern.org.au/remote-sensing/modis/phenology_myd13a1/%s/%s",
     api_key, metric_dir, fname
   )
-  .read_cog(full_url, max_tries, initial_delay)
+  return(.read_cog(full_url, max_tries, initial_delay))
 }

--- a/R/read_slga.R
+++ b/R/read_slga.R
@@ -190,14 +190,14 @@ read_slga <- function(
   attribute <- toupper(attribute)
   attribute <- rlang::arg_match(attribute, approved_attrs)
 
-  read_tern(
+  return(read_tern(
     attribute,
     depth = depth,
     collection = collection,
     api_key = api_key,
     max_tries = max_tries,
     initial_delay = initial_delay
-  )
+  ))
 }
 
 
@@ -280,5 +280,5 @@ read_slga <- function(
     "/vsicurl/https://apikey:%s@data.tern.org.au/model-derived/slga/NationalMaps/SoilAndLandscapeGrid/%s/%s/%s",
     api_key, cfg$dir, cfg$version, fname
   )
-  .read_cog(full_url, max_tries, initial_delay)
+  return(.read_cog(full_url, max_tries, initial_delay))
 }

--- a/R/read_smips.R
+++ b/R/read_smips.R
@@ -87,14 +87,14 @@ read_smips <- function(
   max_tries = NULL,
   initial_delay = NULL
 ) {
-  read_tern(
+  return(read_tern(
     "SMIPS",
     date = date,
     collection = collection,
     api_key = api_key,
     max_tries = max_tries,
     initial_delay = initial_delay
-  )
+  ))
 }
 
 
@@ -134,7 +134,7 @@ read_smips <- function(
     lubridate::year(day),
     dl_file
   )
-  .read_cog(full_url, max_tries, initial_delay)
+  return(.read_cog(full_url, max_tries, initial_delay))
 }
 
 
@@ -175,6 +175,8 @@ read_smips <- function(
       You requested {format(.day, '%Y-%m-%d')}."
     )
   }
+
+  return(invisible(NULL))
 }
 
 

--- a/R/read_soil_diversity.R
+++ b/R/read_soil_diversity.R
@@ -57,14 +57,14 @@ read_soil_diversity <- function(
   max_tries = NULL,
   initial_delay = NULL
 ) {
-  read_tern(
+  return(read_tern(
     "SOILDIV",
     collection = collection,
     axis = axis,
     api_key = api_key,
     max_tries = max_tries,
     initial_delay = initial_delay
-  )
+  ))
 }
 
 
@@ -99,5 +99,5 @@ read_soil_diversity <- function(
     "/vsicurl/https://apikey:%s@data.tern.org.au/model-derived/slga/NationalMaps/Other/SoilBetaDiversity/%s",
     api_key, fname
   )
-  .read_cog(full_url, max_tries, initial_delay)
+  return(.read_cog(full_url, max_tries, initial_delay))
 }

--- a/R/read_tern.R
+++ b/R/read_tern.R
@@ -369,7 +369,7 @@ read_tern <- function(
   api_key <- .check_api_key(api_key %||% get_key())
 
   # Dispatch to specific dataset helpers
-  switch(
+  return(switch(
     did,
     "d1995ee8" = .read_tern_smips(dots, api_key, max_tries, initial_delay),
     "15728dba" = .read_tern_asc(dots, api_key, max_tries, initial_delay),
@@ -391,7 +391,7 @@ read_tern <- function(
     "4a428d52" = .read_tern_soil_diversity(dots, api_key, max_tries, initial_delay),
     "36c98155" = .read_tern_canopy_height(api_key, max_tries, initial_delay),
     "2bb0c81a" = .read_tern_phenology(dots, api_key, max_tries, initial_delay)
-  )
+  ))
 }
 
 
@@ -463,7 +463,7 @@ read_tern <- function(
     ignore.case = TRUE,
     perl = TRUE
   )
-  tolower(id)
+  return(tolower(id))
 }
 
 
@@ -594,5 +594,5 @@ read_tern <- function(
     # Fail-safe
     .tern_not_implemented(dataset_id)
   )
-  invisible(NULL)
+  return(invisible(NULL))
 }

--- a/R/utils-cog.R
+++ b/R/utils-cog.R
@@ -72,5 +72,5 @@
 #'  necessary.
 #' @dev
 .check_api_key <- function(api_key) {
-  gsub("/", "%2f", api_key, fixed = TRUE)
+  return(gsub("/", "%2f", api_key, fixed = TRUE))
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -8,6 +8,7 @@
 # nocov start
 .onLoad <- function(libname, pkgname) {
   .init_nert_options()
+  return(invisible(NULL))
 }
 # nocov end
 
@@ -26,8 +27,6 @@
 #' [base::options()] before `library(nert)`) are preserved; only
 #' unset options are populated with defaults.
 #'
-#' @returns `NULL`, invisibly.  Called for its side effect on
-#'   [base::options()].
 #' @autoglobal
 #' @dev
 .init_nert_options <- function() {
@@ -40,5 +39,4 @@
   if (any(toset)) {
     options(op_nert[toset])
   }
-  invisible(NULL)
 }

--- a/man/dot-init_nert_options.Rd
+++ b/man/dot-init_nert_options.Rd
@@ -6,10 +6,6 @@
 \usage{
 .init_nert_options()
 }
-\value{
-\code{NULL}, invisibly.  Called for its side effect on
-\code{\link[base:options]{base::options()}}.
-}
 \description{
 Extracted from \code{.onLoad()} to allow direct unit testing.  Sets
 package-level defaults for the retry behaviour shared by every


### PR DESCRIPTION
Moved a bit of stuff in R/zzz.R because `.onLoad` is expecting an invisible return and `.init_nert_options` is only setting stuff.