### PR TITLE
docs(slga): correct the SLGA 05/95 layers to a 90% interval

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ Updated version, fixing a number of issues with the TERN dataset retrieval.
   available on the TERN Data Portal, including the monthly SGS/PGS/EGS.
 - `read_slga()` provides access to an additional six datasets (CEC,ECE,
   AVP,PTO,DUL,L15), and also allows the user to pull the 05 and 95
-  percentile limits for the 95% confidence interval.
+  percentile bounds, which together span a 90% interval.
 - `read_asc()` now provides access to its data and confusion index rasters
   using a consistent interface with the rest of the `read_*()` functions.
 - Documentation for the functions and their TERN datasets has been

--- a/R/collect_tern_data.R
+++ b/R/collect_tern_data.R
@@ -34,9 +34,9 @@
 #'   for non-SLGA datasets.
 #' @param stat *For SLGA datasets.* A `character` vector containing the
 #'   statistic to retrieve for the SLGA datasets. (Default=All statistics.)
-#'   Options: `"EV"` (estimated value), `"05"` (lower percentile limit
-#'   for the 95% confidence interval), `"95"` (upper percentile limit for the
-#'   95% confidence interval). Use `NULL` (default) or `"all"` to specify
+#'   Options: `"EV"` (estimated value), `"05"` (lower, 5th-percentile
+#'   bound), `"95"` (upper, 95th-percentile bound); the `05` and `95`
+#'   layers together span a 90% interval. Use `NULL` (default) or `"all"` to specify
 #'   retrieval of all statistics. This parameter is ignored for non-SLGA
 #'   datasets.
 #' @param smips_collection *For SMIPS datasets.* A `character` vector

--- a/R/read_slga.R
+++ b/R/read_slga.R
@@ -5,7 +5,8 @@
 #' attributes are available at 90m X 90m spatial resolution across Australia,
 #' each with six standard depth layers (0-5cm, 5-15cm, 15-30cm, 30-60cm,
 #' 60-100cm, 100-200cm) and three statistics (estimated value, and the lower
-#' (05) and upper (95) percentile limits for the confidence interval).
+#' (05, 5th) and upper (95, 95th) percentile bounds, which together span a
+#' 90% interval).
 #'
 #' @section Supported soil attributes:
 #' \describe{
@@ -33,8 +34,9 @@
 #'   \code{"015_030"}, \code{"030_060"}, \code{"060_100"}, or
 #'   \code{"100_200"}.
 #' @param collection One of \code{"EV"} (estimated value, default),
-#'   \code{"05"} (lower percentile limit for the 95% confidence interval) or
-#'   \code{"95"} (upper percentile limit for the confidence interval).
+#'   \code{"05"} (lower, 5th-percentile bound) or \code{"95"} (upper,
+#'   95th-percentile bound). The 05 and 95 layers together span a 90%
+#'   interval.
 #' @param api_key A \code{character} string containing your \acronym{TERN}
 #'   \acronym{API} key. Defaults to automatic detection from your
 #'   \code{.Renviron} or \code{.Rprofile}.  See [get_key()] for setup.
@@ -62,7 +64,7 @@
 #' # Read available water capacity at 15-30 cm
 #' r_awc <- read_slga("AWC", depth = "015_030")
 #'
-#' # Read pH (CaCl2) confidence interval at 30-60 cm
+#' # Read the pH (CaCl2) 5th- and 95th-percentile bounds at 30-60 cm
 #' r_phc_low <- read_slga("PHC", depth = "030_060", collection = "05")
 #' r_phc_up <- read_slga("PHC", depth = "030_060", collection = "95")
 #'

--- a/R/read_tern.R
+++ b/R/read_tern.R
@@ -76,8 +76,9 @@
 #'     `"015_030"`, `"030_060"`, `"060_100"`, or
 #'     `"100_200"` (cm).}
 #'   \item{`collection`}{One of `"EV"` (estimated value, default),
-#'     `"05"` (lower percentile limit for the 95% confidence interval)
-#'     or `"95"` (upper percentile limit for the confidence interval).}
+#'     `"05"` (lower, 5th-percentile bound) or `"95"` (upper,
+#'     95th-percentile bound). The `05` and `95` layers together span a
+#'     90% interval, per the SLGA product definition.}
 #' }
 #' Supported attributes (use as the `dataset_id` alias):
 #' \describe{

--- a/man/collect_tern_data.Rd
+++ b/man/collect_tern_data.Rd
@@ -62,9 +62,9 @@ for non-SLGA datasets.}
 
 \item{stat}{\emph{For SLGA datasets.} A \code{character} vector containing the
 statistic to retrieve for the SLGA datasets. (Default=All statistics.)
-Options: \code{"EV"} (estimated value), \code{"05"} (lower percentile limit
-for the 95\% confidence interval), \code{"95"} (upper percentile limit for the
-95\% confidence interval). Use \code{NULL} (default) or \code{"all"} to specify
+Options: \code{"EV"} (estimated value), \code{"05"} (lower, 5th-percentile
+bound), \code{"95"} (upper, 95th-percentile bound); the \code{05} and \code{95}
+layers together span a 90\% interval. Use \code{NULL} (default) or \code{"all"} to specify
 retrieval of all statistics. This parameter is ignored for non-SLGA
 datasets.}
 

--- a/man/read_slga.Rd
+++ b/man/read_slga.Rd
@@ -24,8 +24,9 @@ read_slga(
 \code{"100_200"}.}
 
 \item{collection}{One of \code{"EV"} (estimated value, default),
-\code{"05"} (lower percentile limit for the 95\% confidence interval) or
-\code{"95"} (upper percentile limit for the confidence interval).}
+\code{"05"} (lower, 5th-percentile bound) or \code{"95"} (upper,
+95th-percentile bound). The 05 and 95 layers together span a 90\%
+interval.}
 
 \item{api_key}{A \code{character} string containing your \acronym{TERN}
 \acronym{API} key. Defaults to automatic detection from your
@@ -51,7 +52,8 @@ Grid of Australia (SLGA) datasets from the TERN Data Portal. 14 soil
 attributes are available at 90m X 90m spatial resolution across Australia,
 each with six standard depth layers (0-5cm, 5-15cm, 15-30cm, 30-60cm,
 60-100cm, 100-200cm) and three statistics (estimated value, and the lower
-(05) and upper (95) percentile limits for the confidence interval).
+(05, 5th) and upper (95, 95th) percentile bounds, which together span a
+90\% interval).
 }
 \section{Supported soil attributes}{
 
@@ -82,7 +84,7 @@ autoplot(r)
 # Read available water capacity at 15-30 cm
 r_awc <- read_slga("AWC", depth = "015_030")
 
-# Read pH (CaCl2) confidence interval at 30-60 cm
+# Read the pH (CaCl2) 5th- and 95th-percentile bounds at 30-60 cm
 r_phc_low <- read_slga("PHC", depth = "030_060", collection = "05")
 r_phc_up <- read_slga("PHC", depth = "030_060", collection = "95")
 \dontshow{\}) # examplesIf}

--- a/man/read_tern.Rd
+++ b/man/read_tern.Rd
@@ -127,8 +127,9 @@ depth layers and three statistics:
 \code{"015_030"}, \code{"030_060"}, \code{"060_100"}, or
 \code{"100_200"} (cm).}
 \item{\code{collection}}{One of \code{"EV"} (estimated value, default),
-\code{"05"} (lower percentile limit for the 95\% confidence interval)
-or \code{"95"} (upper percentile limit for the confidence interval).}
+\code{"05"} (lower, 5th-percentile bound) or \code{"95"} (upper,
+95th-percentile bound). The \code{05} and \code{95} layers together span a
+90\% interval, per the SLGA product definition.}
 }
 Supported attributes (use as the \code{dataset_id} alias):
 \describe{

--- a/vignettes/collect_tern_data.Rmd
+++ b/vignettes/collect_tern_data.Rmd
@@ -59,7 +59,7 @@ head(dt)
 
 When `verbose = TRUE` (default), a list of the datasets that will be collected is generated in the output, together with progress messages as the data points are downloaded.
 
-By default, `collect_tern_data()` extracts _all available dataset variants_ unless you specify a smaller subset. For instance, in the above code, we collect all of the available SMIPS datasets: `"totalbucket"`, `"SMindex"`, `"bucket1"`, `"bucket2"`, `"deepD"`, and `"runoff"`. Extracting the other datasets works similarly. If we use `collect_tern_data()` to download data for the SLGA available water capacity dataset `"AWC"`, by default it will download the data for all available depths, as well as all three statistics (the estimated value `EV`, as well as the 95% confidence interval limits `05` and `95`):
+By default, `collect_tern_data()` extracts _all available dataset variants_ unless you specify a smaller subset. For instance, in the above code, we collect all of the available SMIPS datasets: `"totalbucket"`, `"SMindex"`, `"bucket1"`, `"bucket2"`, `"deepD"`, and `"runoff"`. Extracting the other datasets works similarly. If we use `collect_tern_data()` to download data for the SLGA available water capacity dataset `"AWC"`, by default it will download the data for all available depths, as well as all three statistics (the estimated value `EV`, plus the `05` and `95` percentile bounds, which together span a 90% interval):
 
 
 ``` r

--- a/vignettes/collect_tern_data.Rmd.orig
+++ b/vignettes/collect_tern_data.Rmd.orig
@@ -44,7 +44,7 @@ head(dt)
 
 When `verbose = TRUE` (default), a list of the datasets that will be collected is generated in the output, together with progress messages as the data points are downloaded.
 
-By default, `collect_tern_data()` extracts _all available dataset variants_ unless you specify a smaller subset. For instance, in the above code, we collect all of the available SMIPS datasets: `"totalbucket"`, `"SMindex"`, `"bucket1"`, `"bucket2"`, `"deepD"`, and `"runoff"`. Extracting the other datasets works similarly. If we use `collect_tern_data()` to download data for the SLGA available water capacity dataset `"AWC"`, by default it will download the data for all available depths, as well as all three statistics (the estimated value `EV`, as well as the 95% confidence interval limits `05` and `95`):
+By default, `collect_tern_data()` extracts _all available dataset variants_ unless you specify a smaller subset. For instance, in the above code, we collect all of the available SMIPS datasets: `"totalbucket"`, `"SMindex"`, `"bucket1"`, `"bucket2"`, `"deepD"`, and `"runoff"`. Extracting the other datasets works similarly. If we use `collect_tern_data()` to download data for the SLGA available water capacity dataset `"AWC"`, by default it will download the data for all available depths, as well as all three statistics (the estimated value `EV`, plus the `05` and `95` percentile bounds, which together span a 90% interval):
 
 ```{r collect-awc}
 dt <- collect_tern_data(


### PR DESCRIPTION
## What

The SLGA `"05"` and `"95"` layers are documented as the bounds of a *"95%
confidence interval"*. They are the 5th- and 95th-percentile bounds of the
model's predictive distribution, so together they span a **90% interval**, not
95%. This corrects the wording everywhere it appears.

## Why it is 90%, not 95%

The interval between the 5th and 95th percentiles contains 90% of the
distribution. The "95%" almost certainly came from the upper-bound label
(`"95"`). The SLGA product page states it directly: *"90% of the time the model
value is expected to be within the range of the values given by these
intervals"* (esoil.io / Soil and Landscape Grid of Australia). The word
"interval" is kept (the source uses it); only the coverage figure was wrong.

## Changes (one wording fix, applied to every surface)

- `R/read_slga.R` — function description, the `collection` argument, and the
  worked example comment.
- `R/read_tern.R` — the SLGA section of the dispatcher documentation.
- `R/collect_tern_data.R` — the `stat` argument.
- `vignettes/collect_tern_data.Rmd` and its `.Rmd.orig` source (prose only).
- `NEWS.md` — the 1.1.0 entry repeated the same "95% confidence interval"
  wording; corrected in place.
- The three regenerated man pages (`read_slga.Rd`, `read_tern.Rd`,
  `collect_tern_data.Rd`).

## Verification

`devtools::test()` green (`FAIL 0 … PASS 793`); `tools::checkRd()` clean on the
changed man pages. No code paths change. (Man pages were mirrored by hand
because the project pins roxygen2 8.0.0 + devtag, which I could not reproduce
locally — a `devtools::document()` pass with the project toolchain should be a
no-op.)
