### PR TITLE
docs(asc): document the Calcarosol order's variant raster label

### DIFF
--- a/R/read_asc.R
+++ b/R/read_asc.R
@@ -15,7 +15,10 @@
 #'       estimated ASC soil order class. Each pixel of the raster maps to one
 #'       of 14 soil order classes: Vertosol, Sodosol, Dermosol, Chromosol,
 #'       Ferrosol, Kurosol, Tenosol, Kandosol, Hydrosol, Podosol, Rudosol,
-#'       Calcarasol, Organosol, Anthroposol.}
+#'       Calcarasol, Organosol, Anthroposol. The class listed here as
+#'       \code{"Calcarasol"} reproduces the spelling carried in the TERN
+#'       raster's own category labels; the canonical Australian Soil
+#'       Classification spelling of this soil order is \code{"Calcarosol"}.}
 #'     \item{\code{"CI"}}{**Confusion Index** (0-1). A unitless index between
 #'       0.0 and 1.0, approximating the uncertainty of the Random Forest
 #'       classification for the soil order at each pixel. (A higher value of the

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -36,6 +36,7 @@ CSIRO
 CUR2210
 CaCl2
 Calcarasol
+Calcarosol
 Chromosol
 Classification
 DUL

--- a/man/read_asc.Rd
+++ b/man/read_asc.Rd
@@ -18,7 +18,10 @@ read_asc(
 estimated ASC soil order class. Each pixel of the raster maps to one
 of 14 soil order classes: Vertosol, Sodosol, Dermosol, Chromosol,
 Ferrosol, Kurosol, Tenosol, Kandosol, Hydrosol, Podosol, Rudosol,
-Calcarasol, Organosol, Anthroposol.}
+Calcarasol, Organosol, Anthroposol. The class listed here as
+\code{"Calcarasol"} reproduces the spelling carried in the TERN
+raster's own category labels; the canonical Australian Soil
+Classification spelling of this soil order is \code{"Calcarosol"}.}
 \item{\code{"CI"}}{\strong{Confusion Index} (0-1). A unitless index between
 0.0 and 1.0, approximating the uncertainty of the Random Forest
 classification for the soil order at each pixel. (A higher value of the


### PR DESCRIPTION
## What

`read_asc()` lists the 14 ASC soil order classes, one of which is spelt
**"Calcarasol"**. The canonical Australian Soil Classification order is
**"Calcarosol"** (Isbell & the National Committee on Soil and Terrain; CSIRO
ACLEP).

## Why this is a note, not a straight rename

The label is not nert's — it is TERN's. The ASC EV raster's embedded category
table itself carries the variant spelling: `read_asc("EV")` returns a categorical
raster whose category 12 is labelled `"12 - Calcarasol"` (confirmed live against
the data server). nert returns the raster faithfully, so renaming the class in
the docs to "Calcarosol" would make the documentation disagree with what the
function actually emits.

So this PR keeps **"Calcarasol"** in the class list (it matches the raster) and
adds a one-line note that the canonical ASC spelling of the order is
**"Calcarosol"**. A user filtering the raster's categories still finds the string
they will see; a reader gets the correct taxonomic name.

If you would rather treat the upstream label as something nert should silently
correct, that is a different (larger) change — happy to discuss.

## Changes

- `R/read_asc.R` — the `"EV"` collection class list gains the canonical-spelling
  note.
- `man/read_asc.Rd` — regenerated to match.
- `inst/WORDLIST` — adds "Calcarosol".

## Verification

`devtools::test()` green (`FAIL 0 … PASS 793`); `tools::checkRd()` clean;
`spelling::spell_check_package()` no longer flags "Calcarosol".
