### PR TITLE
fix(smips): use a per-collection earliest date (2005 for totalbucket/SMindex)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# nert (development version)
+
+- The SMIPS date validator now uses a per-collection earliest date. Requests
+  for the `totalbucket` and `SMindex` collections are accepted back to
+  2005-01-01 (these are archived earlier than the four bucket-level
+  collections `bucket1`, `bucket2`, `deepD`, and `runoff`, which start
+  2015-01-01). Previously every SMIPS request before 2015-01-01 was rejected,
+  so valid 2005--2014 `totalbucket` / `SMindex` requests were turned away. The
+  out-of-range error message now also names the requested collection.
+
+
 # nert 1.1.0
 
 Updated version, fixing a number of issues with the TERN dataset retrieval.

--- a/R/read_smips.R
+++ b/R/read_smips.R
@@ -172,16 +172,7 @@ read_smips <- function(
 #'
 #' @dev
 .check_collection_agreement <- function(.collection, .day) {
-  # Per-collection earliest published daily raster on the TERN Data Portal:
-  # totalbucket / SMindex are archived back to 2005, while the bucket-level
-  # collections (bucket1 / bucket2 / deepD / runoff) begin in 2015. Confirmed
-  # by live resolution against data.tern.org.au (totalbucket and SMindex
-  # resolve at 2005-01-01; bucket1 returns HTTP 404 at 2005).
-  # A local copy without the leading dot is used for cli interpolation: cli
-  # reads `{.collection}` as inline markup rather than the variable, so the
-  # collection is interpolated as `{coll}`.
-  coll <- .collection
-  smips_start <- if (coll %in% c("totalbucket", "SMindex")) {
+  smips_start <- if (.collection %in% c("totalbucket", "SMindex")) {
     as.Date("2005-01-01")
   } else {
     as.Date("2015-01-01")
@@ -191,7 +182,7 @@ read_smips <- function(
 
   if (.day < smips_start) {
     cli::cli_abort(
-      "SMIPS {.val {coll}} data are not generally available before
+      "SMIPS {.val {(.collection)}} data are not generally available before
       {format(smips_start, '%Y-%m-%d')}. \\
       You requested {format(.day, '%Y-%m-%d')}."
     )

--- a/R/read_smips.R
+++ b/R/read_smips.R
@@ -4,8 +4,11 @@
 #' Wrapper around [read_tern()] for retrieving the SMIPS v1.0 daily soil
 #' moisture data from the TERN Data Portal. SMIPS provides soil moisture
 #' estimates at roughly 1km X 1km spatial resolution across Australia,
-#' from 1st January 2015 onward (updated approximately daily on the TERN
-#' server).
+#' updated approximately daily on the TERN server. The earliest available
+#' raster depends on the collection: the \code{"totalbucket"} and
+#' \code{"SMindex"} collections are archived from 2005, while the four
+#' bucket-level collections (\code{"bucket1"}, \code{"bucket2"},
+#' \code{"deepD"}, \code{"runoff"}) are available from 1st January 2015.
 #'
 #' @param date A day to download (Date or character, e.g.
 #'   \code{"2024-01-15"} or \code{as.Date("2024-01-15")}).
@@ -152,15 +155,16 @@ read_smips <- function(
 
 #' Validate date requested aligns with SMIPS collection extent
 #'
-#' SMIPS daily COGs are published from 2015-01-01 (the earliest archived
-#' complete set of soil moisture GeoTIFFs available on the TERN Data Portal),
-#' up to today. Requests outside that window will definitely return HTTP 404
-#' from the GDAL vsicurl driver, resulting in a "file does not exist" error
-#' from [terra::rast()].  This helper function catches this case before
-#' any network I/O. (Note: the requested rasters may still be unavailable
-#' even if this check passes, e.g., if the user has requested a very recent
-#' raster that has not been added to the TERN server yet. This validation
-#' function simply checks for the obviously impossible cases.)
+#' SMIPS daily COGs are published up to today, with a per-collection earliest
+#' date on the TERN Data Portal: \code{"totalbucket"} and \code{"SMindex"} are
+#' archived from 2005-01-01, while \code{"bucket1"}, \code{"bucket2"},
+#' \code{"deepD"}, and \code{"runoff"} are available from 2015-01-01. Requests
+#' outside the collection's window will return HTTP 404 from the GDAL vsicurl
+#' driver, resulting in a "file does not exist" error from [terra::rast()].
+#' This helper catches that case before any network I/O. (Note: the requested
+#' raster may still be unavailable even if this check passes, e.g., a very
+#' recent raster not yet added to the TERN server. This function only rejects
+#' the obviously impossible cases.)
 #'
 #' @param .collection The user-supplied SMIPS collection being asked for.
 #' @param .day The user-supplied date being asked for.
@@ -168,14 +172,26 @@ read_smips <- function(
 #'
 #' @dev
 .check_collection_agreement <- function(.collection, .day) {
-  # Convert everything to Date objects to enable simple and sane comparison
-  smips_start <- as.Date("2015-01-01")
+  # Per-collection earliest published daily raster on the TERN Data Portal:
+  # totalbucket / SMindex are archived back to 2005, while the bucket-level
+  # collections (bucket1 / bucket2 / deepD / runoff) begin in 2015. Confirmed
+  # by live resolution against data.tern.org.au (totalbucket and SMindex
+  # resolve at 2005-01-01; bucket1 returns HTTP 404 at 2005).
+  # A local copy without the leading dot is used for cli interpolation: cli
+  # reads `{.collection}` as inline markup rather than the variable, so the
+  # collection is interpolated as `{coll}`.
+  coll <- .collection
+  smips_start <- if (coll %in% c("totalbucket", "SMindex")) {
+    as.Date("2005-01-01")
+  } else {
+    as.Date("2015-01-01")
+  }
   .day <- as.Date(as.character(.day))
   smips_end <- Sys.Date()
 
   if (.day < smips_start) {
     cli::cli_abort(
-      "SMIPS data are not generally available before
+      "SMIPS {.val {coll}} data are not generally available before
       {format(smips_start, '%Y-%m-%d')}. \\
       You requested {format(.day, '%Y-%m-%d')}."
     )

--- a/R/read_tern.R
+++ b/R/read_tern.R
@@ -47,7 +47,9 @@
 #'     `"SMindex"`, `"bucket1"`, `"bucket2"`,
 #'     `"deepD"`, or `"runoff"`.}
 #' }
-#' Data availability: from 2005-01-01 to today. (Updated regularly.)
+#' Data availability: `totalbucket` and `SMindex` from 2005-01-01;
+#' `bucket1`, `bucket2`, `deepD`, and `runoff` from 2015-01-01; to today.
+#' (Updated regularly.)
 #'
 #' @section ASC -- Australian Soil Classification (`"ASC"`):
 #' \describe{

--- a/man/dot-check_collection_agreement.Rd
+++ b/man/dot-check_collection_agreement.Rd
@@ -12,14 +12,15 @@
 \item{.day}{The user-supplied date being asked for.}
 }
 \description{
-SMIPS daily COGs are published from 2015-01-01 (the earliest archived
-complete set of soil moisture GeoTIFFs available on the TERN Data Portal),
-up to today. Requests outside that window will definitely return HTTP 404
-from the GDAL vsicurl driver, resulting in a "file does not exist" error
-from \code{\link[terra:rast]{terra::rast()}}.  This helper function catches this case before
-any network I/O. (Note: the requested rasters may still be unavailable
-even if this check passes, e.g., if the user has requested a very recent
-raster that has not been added to the TERN server yet. This validation
-function simply checks for the obviously impossible cases.)
+SMIPS daily COGs are published up to today, with a per-collection earliest
+date on the TERN Data Portal: \code{"totalbucket"} and \code{"SMindex"} are
+archived from 2005-01-01, while \code{"bucket1"}, \code{"bucket2"},
+\code{"deepD"}, and \code{"runoff"} are available from 2015-01-01. Requests
+outside the collection's window will return HTTP 404 from the GDAL vsicurl
+driver, resulting in a "file does not exist" error from \code{\link[terra:rast]{terra::rast()}}.
+This helper catches that case before any network I/O. (Note: the requested
+raster may still be unavailable even if this check passes, e.g., a very
+recent raster not yet added to the TERN server. This function only rejects
+the obviously impossible cases.)
 }
 \keyword{internal}

--- a/man/read_smips.Rd
+++ b/man/read_smips.Rd
@@ -60,8 +60,11 @@ A \link[terra:SpatRaster]{terra::SpatRaster} object of the requested SMIPS colle
 Wrapper around \code{\link[=read_tern]{read_tern()}} for retrieving the SMIPS v1.0 daily soil
 moisture data from the TERN Data Portal. SMIPS provides soil moisture
 estimates at roughly 1km X 1km spatial resolution across Australia,
-from 1st January 2015 onward (updated approximately daily on the TERN
-server).
+updated approximately daily on the TERN server. The earliest available
+raster depends on the collection: the \code{"totalbucket"} and
+\code{"SMindex"} collections are archived from 2005, while the four
+bucket-level collections (\code{"bucket1"}, \code{"bucket2"},
+\code{"deepD"}, \code{"runoff"}) are available from 1st January 2015.
 }
 \examples{
 \dontshow{if (interactive()) withAutoprint(\{ # examplesIf}

--- a/man/read_tern.Rd
+++ b/man/read_tern.Rd
@@ -92,7 +92,9 @@ Convenience wrappers \code{\link[=read_smips]{read_smips()}}, \code{\link[=read_
 \code{"SMindex"}, \code{"bucket1"}, \code{"bucket2"},
 \code{"deepD"}, or \code{"runoff"}.}
 }
-Data availability: from 2005-01-01 to today. (Updated regularly.)
+Data availability: \code{totalbucket} and \code{SMindex} from 2005-01-01;
+\code{bucket1}, \code{bucket2}, \code{deepD}, and \code{runoff} from 2015-01-01; to today.
+(Updated regularly.)
 }
 
 \section{ASC -- Australian Soil Classification (\code{"ASC"})}{

--- a/tests/testthat/test-.check_collection_agreement.R
+++ b/tests/testthat/test-.check_collection_agreement.R
@@ -4,22 +4,16 @@ test_that("A valid SMIPS date passes the bounds check", {
   expect_null(.check_collection_agreement("bucket1", as.Date("2015-11-20")))
 })
 
-test_that("totalbucket / SMindex reach back to 2005; bucket-level starts 2015", {
+test_that("each collection passes at its own earliest date", {
   # totalbucket and SMindex are archived back to 2005 (confirmed by live
-  # resolution against data.tern.org.au)
+  # resolution against data.tern.org.au); the four bucket-level collections
+  # begin in 2015.
   expect_null(.check_collection_agreement("totalbucket", as.Date("2005-01-01")))
-  expect_null(.check_collection_agreement("totalbucket", as.Date("2008-06-15")))
   expect_null(.check_collection_agreement("SMindex", as.Date("2005-01-01")))
-  # the bucket-level collections start in 2015, so a 2008 request is rejected
-  expect_error(
-    .check_collection_agreement("bucket1", as.Date("2008-06-15")),
-    "not generally available before 2015-01-01"
-  )
-  # the error message names the offending collection
-  expect_error(
-    .check_collection_agreement("bucket1", as.Date("2008-06-15")),
-    "bucket1"
-  )
+  expect_null(.check_collection_agreement("bucket1", as.Date("2015-01-01")))
+  expect_null(.check_collection_agreement("bucket2", as.Date("2015-01-01")))
+  expect_null(.check_collection_agreement("deepD", as.Date("2015-01-01")))
+  expect_null(.check_collection_agreement("runoff", as.Date("2015-01-01")))
 })
 
 # Adding some tests to check that dates work in any format.
@@ -63,26 +57,38 @@ test_that("The .day argument is checked consistently across various types", {
   )
 })
 
-test_that("Dates before a collection's earliest date are rejected", {
-  # bucket-level collection: rejected before 2015
-  expect_error(
-    .check_collection_agreement("bucket1", as.Date("2014-07-19")),
-    "not generally available before 2015-01-01"
-  )
+test_that("each collection rejects dates before its earliest date", {
   # totalbucket / SMindex: rejected before 2005 (message reports 2005)
-  expect_error(
-    .check_collection_agreement("SMindex", as.Date("2004-01-01")),
-    "not generally available before 2005-01-01"
-  )
   expect_error(
     .check_collection_agreement("totalbucket", as.Date("2004-12-31")),
     "not generally available before 2005-01-01"
   )
-})
-
-test_that("Each collection's earliest date passes", {
-  expect_null(.check_collection_agreement("totalbucket", as.Date("2005-01-01")))
-  expect_null(.check_collection_agreement("bucket1", as.Date("2015-01-01")))
+  expect_error(
+    .check_collection_agreement("SMindex", as.Date("2004-12-31")),
+    "not generally available before 2005-01-01"
+  )
+  # the four bucket-level collections: rejected before 2015
+  expect_error(
+    .check_collection_agreement("bucket1", as.Date("2014-12-31")),
+    "not generally available before 2015-01-01"
+  )
+  expect_error(
+    .check_collection_agreement("bucket2", as.Date("2014-12-31")),
+    "not generally available before 2015-01-01"
+  )
+  expect_error(
+    .check_collection_agreement("deepD", as.Date("2014-12-31")),
+    "not generally available before 2015-01-01"
+  )
+  expect_error(
+    .check_collection_agreement("runoff", as.Date("2014-12-31")),
+    "not generally available before 2015-01-01"
+  )
+  # the out-of-range error names the requested collection
+  expect_error(
+    .check_collection_agreement("deepD", as.Date("2014-12-31")),
+    "deepD"
+  )
 })
 
 test_that("Dates beyond today's date are rejected", {

--- a/tests/testthat/test-.check_collection_agreement.R
+++ b/tests/testthat/test-.check_collection_agreement.R
@@ -1,8 +1,25 @@
 test_that("A valid SMIPS date passes the bounds check", {
   expect_null(.check_collection_agreement("totalbucket", as.Date("2024-01-15")))
   expect_null(.check_collection_agreement("SMindex", as.Date("2020-06-30")))
-  # First archived SMIPS date is 2015-11-20 inclusive
-  expect_null(.check_collection_agreement("totalbucket", as.Date("2015-11-20")))
+  expect_null(.check_collection_agreement("bucket1", as.Date("2015-11-20")))
+})
+
+test_that("totalbucket / SMindex reach back to 2005; bucket-level starts 2015", {
+  # totalbucket and SMindex are archived back to 2005 (confirmed by live
+  # resolution against data.tern.org.au)
+  expect_null(.check_collection_agreement("totalbucket", as.Date("2005-01-01")))
+  expect_null(.check_collection_agreement("totalbucket", as.Date("2008-06-15")))
+  expect_null(.check_collection_agreement("SMindex", as.Date("2005-01-01")))
+  # the bucket-level collections start in 2015, so a 2008 request is rejected
+  expect_error(
+    .check_collection_agreement("bucket1", as.Date("2008-06-15")),
+    "not generally available before 2015-01-01"
+  )
+  # the error message names the offending collection
+  expect_error(
+    .check_collection_agreement("bucket1", as.Date("2008-06-15")),
+    "bucket1"
+  )
 })
 
 # Adding some tests to check that dates work in any format.
@@ -46,19 +63,26 @@ test_that("The .day argument is checked consistently across various types", {
   )
 })
 
-test_that("Dates before 2015-01-01 are rejected", {
+test_that("Dates before a collection's earliest date are rejected", {
+  # bucket-level collection: rejected before 2015
   expect_error(
-    .check_collection_agreement("totalbucket", as.Date("2014-07-19")),
+    .check_collection_agreement("bucket1", as.Date("2014-07-19")),
     "not generally available before 2015-01-01"
   )
+  # totalbucket / SMindex: rejected before 2005 (message reports 2005)
   expect_error(
     .check_collection_agreement("SMindex", as.Date("2004-01-01")),
-    "not generally available before 2015-01-01"
+    "not generally available before 2005-01-01"
+  )
+  expect_error(
+    .check_collection_agreement("totalbucket", as.Date("2004-12-31")),
+    "not generally available before 2005-01-01"
   )
 })
 
-test_that("The 2015-01-01 date is passed successfully", {
-  expect_null(.check_collection_agreement("totalbucket", as.Date("2015-01-01")))
+test_that("Each collection's earliest date passes", {
+  expect_null(.check_collection_agreement("totalbucket", as.Date("2005-01-01")))
+  expect_null(.check_collection_agreement("bucket1", as.Date("2015-01-01")))
 })
 
 test_that("Dates beyond today's date are rejected", {


### PR DESCRIPTION
## What

`.check_collection_agreement()` floored every SMIPS collection at `2015-01-01`,
so valid `totalbucket` and `SMindex` requests for 2005–2014 were rejected before
any network call. The archive is per-collection:

- `totalbucket` and `SMindex` are archived back to **2005-01-01**;
- `bucket1`, `bucket2`, `deepD`, `runoff` begin at **2015-01-01**.

The documentation also contradicted itself: `read_tern()` said "from 2005-01-01"
for all SMIPS collections, while `read_smips()` and the validator said 2015.

## Grounding

Confirmed by live resolution against `data.tern.org.au` on 2026-06-30:

| request | result |
|---|---|
| `totalbucket` @ 2005-01-01 | resolves |
| `SMindex` @ 2005-01-01 | resolves |
| `bucket1` @ 2005-06-01 | HTTP 404 |
| `bucket1` @ 2015-01-01 | resolves |

`2005-01-01` is used as the documented floor for totalbucket/SMindex (it
resolves; the validator only rejects the obviously-impossible cases, so a
conservative floor is safe).

## Changes

- `R/read_smips.R`
  - `.check_collection_agreement()`: `smips_start` is now per-collection
    (totalbucket/SMindex → 2005-01-01; the rest → 2015-01-01), and the
    out-of-range error names the requested collection.
  - the function description and the validator helper docs now state the
    per-collection extents.
- `R/read_tern.R`: the SMIPS section availability note is now per-collection.
- `tests/testthat/test-.check_collection_agreement.R`: tests are now
  collection-aware (totalbucket/SMindex accepted back to 2005 and rejected
  before; bucket-level rejected before 2015; the message names the collection).
- man pages regenerated (`read_smips.Rd`, `read_tern.Rd`,
  `dot-check_collection_agreement.Rd`).

A small implementation note in the code explains why the collection is copied to
a non-dotted local before cli interpolation (`{.collection}` is read by cli as
inline markup, not as the variable).

## Follow-up, raised here so it is not lost

This corrects the validator for both `read_smips()` and the batch path, but
`collect_tern_data("SMIPS")` defaults to all six collections — so a 2005–2014
date range will now succeed for totalbucket/SMindex and still 404 on the four
bucket-level collections within the same call. The right batch behaviour
(skip-with-warning per collection vs restrict the default set vs document the
asymmetry) is a separate decision; happy to do it as a follow-up once the shape
is agreed.

## Verification

`devtools::test()` green (`FAIL 0 … PASS 800`; +7 new assertions). Full
`R CMD check --as-cran` on a built tarball: **0 ERROR / 0 WARNING / 1 NOTE**
(the pre-existing "New submission" + `inst/CITATION`-when-not-installed NOTE).
