### PR TITLE
docs(smips): correct the deepD upper bucket depth to 0-10cm

### DIFF
--- a/R/read_smips.R
+++ b/R/read_smips.R
@@ -24,7 +24,7 @@
 #'       An estimate of the volumetric soil moisture of the lower 10-90cm
 #'       soil bucket.}
 #'     \item{\code{"deepD"}}{**Drainage between two buckets** (mm).
-#'       An estimate of the drainage from the top 0-1cm soil bucket through
+#'       An estimate of the drainage from the upper 0-10cm soil bucket through
 #'       to the lower 10-90cm bucket.}
 #'     \item{\code{"runoff"}}{**Runoff/overtopping moisture loss** (mm).
 #'       An estimate of the moisture lost from the top 0-10cm bucket due to

--- a/man/read_smips.Rd
+++ b/man/read_smips.Rd
@@ -31,7 +31,7 @@ soil bucket.}
 An estimate of the volumetric soil moisture of the lower 10-90cm
 soil bucket.}
 \item{\code{"deepD"}}{\strong{Drainage between two buckets} (mm).
-An estimate of the drainage from the top 0-1cm soil bucket through
+An estimate of the drainage from the upper 0-10cm soil bucket through
 to the lower 10-90cm bucket.}
 \item{\code{"runoff"}}{\strong{Runoff/overtopping moisture loss} (mm).
 An estimate of the moisture lost from the top 0-10cm bucket due to


### PR DESCRIPTION
## What

The `deepD` collection estimates drainage from the upper SMIPS bucket into the
lower one. Its description gives the upper bucket as **"top 0-1cm"**. The SMIPS
two-layer model's upper bucket is **0-10cm** — as the `bucket1` and `runoff`
descriptions in the same documentation already state. A dropped zero.

## Source

The SMIPS two-bucket model: upper bucket 0-10cm, lower bucket 10-90cm (Stenson et
al. 2021, the dataset already cited in `read_smips()`). `bucket1` is documented as
"the upper 0-10cm bucket" two items above `deepD`.

## Changes

- `R/read_smips.R` — `deepD` description: "top 0-1cm" → "upper 0-10cm".
- `man/read_smips.Rd` — regenerated to match.

## Verification

`devtools::test()` green (`FAIL 0 … PASS 793`); `tools::checkRd()` clean. After
this change all three bucket-depth mentions in `read_smips()` agree (0-10cm
upper, 10-90cm lower).
