### PR TITLE
fix(phenology,soildiv): guard non-scalar season/axis with a clear message

### DIFF
--- a/R/read_phenology.R
+++ b/R/read_phenology.R
@@ -199,6 +199,12 @@ read_phenology <- function(
   approved_metrics <- names(.phenology_metrics)
   collection <- rlang::arg_match(collection, approved_metrics)
 
+  if (length(season) != 1L) {
+    cli::cli_abort(
+      "Phenology {.arg season} must be a single value; got length \\
+       {.val {length(season)}}."
+    )
+  }
   if (!season %in% 1L:2L) {
     cli::cli_abort("Phenology {.arg season} must be 1 or 2.")
   }

--- a/R/read_soil_diversity.R
+++ b/R/read_soil_diversity.R
@@ -97,6 +97,12 @@ read_soil_diversity <- function(
   approved_collections <- c("Bacteria", "Fungi")
   collection <- rlang::arg_match(collection, approved_collections)
 
+  if (length(axis) != 1L) {
+    cli::cli_abort(
+      "Soil Beta Diversity {.arg axis} must be a single value; got length \\
+       {.val {length(axis)}}."
+    )
+  }
   if (!axis %in% 1L:3L) {
     cli::cli_abort("Soil Beta Diversity {.arg axis} must be 1, 2, or 3.")
   }

--- a/tests/testthat/test-read_phenology.R
+++ b/tests/testthat/test-read_phenology.R
@@ -95,6 +95,13 @@ test_that("season must be 1 or 2", {
   )
 })
 
+test_that("a non-scalar season is rejected with a clear message", {
+  expect_error(
+    read_phenology(year = 2018L, season = c(1L, 2L), api_key = KEY),
+    "must be a single value"
+  )
+})
+
 # ---- Year validator --------------------------------------------------------
 
 test_that("year < 2003 is rejected", {

--- a/tests/testthat/test-read_soil_diversity.R
+++ b/tests/testthat/test-read_soil_diversity.R
@@ -50,6 +50,13 @@ test_that("axis must be 1, 2, or 3", {
   )
 })
 
+test_that("a non-scalar axis is rejected with a clear message", {
+  expect_error(
+    read_soil_diversity(axis = c(1L, 2L), api_key = KEY),
+    "must be a single value"
+  )
+})
+
 test_that("collection must be Bacteria or Fungi", {
   expect_error(
     read_soil_diversity(collection = "Archaea", api_key = KEY),


### PR DESCRIPTION
## What

`read_phenology(season = c(1, 2))` and `read_soil_diversity(axis = c(1, 2))`
raised R's opaque *"the condition has length greater than 1"* (a hard error in
R >= 4.3) from the `!season %in% 1L:2L` / `!axis %in% 1L:3L` membership tests,
instead of the intended "must be 1 or 2" / "must be 1, 2, or 3" message.

## Fix

Add a `length(...) != 1L` guard before each membership test, mirroring the guard
`.validate_phenology()` already applies to `year`. The user now gets a clear
"must be a single value" message.

## Changes

- `R/read_phenology.R` — length guard before the `season` membership test.
- `R/read_soil_diversity.R` — length guard before the `axis` membership test.
- Tests: a non-scalar `season` / `axis` is rejected with the clear message,
  added to the existing `season`/`axis` validation blocks.

## Verification

`devtools::test()` green; air-clean. No roxygen change, so no `man/` update.
