### PR TITLE
fix(collect): make the "all" sentinel case-insensitive

### DIFF
--- a/R/collect_tern_data.R
+++ b/R/collect_tern_data.R
@@ -372,7 +372,7 @@ collect_tern_data <- function(
 #'   order preserved).
 #' @dev
 .normalise_vector_elements <- function(vec, valid_elements, info) {
-  if (is.null(vec) || (length(vec) == 1 && identical(tolower(vec), "all"))) {
+  if (is.null(vec) || (length(vec) == 1 && identical(toupper(vec), "ALL"))) {
     return(valid_elements)
   }
 
@@ -380,7 +380,8 @@ collect_tern_data <- function(
   if (length(vec) == 0) {
     cli::cli_abort("No {info} specified.")
   }
-  invalid_elements <- setdiff(vec, valid_elements)
+  canonical <- valid_elements[match(toupper(vec), toupper(valid_elements))]
+  invalid_elements <- vec[is.na(canonical)]
   if (length(invalid_elements) > 0) {
     cli::cli_warn(
       c(
@@ -388,12 +389,12 @@ collect_tern_data <- function(
         "i" = "Valid {info}: {.val {valid_elements}}."
       )
     )
-    vec <- intersect(vec, valid_elements)
   }
-  if (length(vec) == 0) {
+  canonical <- unique(canonical[!is.na(canonical)])
+  if (length(canonical) == 0) {
     cli::cli_abort("No valid {info} remained after filtering.")
   }
-  return(vec)
+  return(canonical)
 }
 
 

--- a/R/collect_tern_data.R
+++ b/R/collect_tern_data.R
@@ -372,7 +372,7 @@ collect_tern_data <- function(
 #'   order preserved).
 #' @dev
 .normalise_vector_elements <- function(vec, valid_elements, info) {
-  if (is.null(vec) || (length(vec) == 1 && identical(vec, "all"))) {
+  if (is.null(vec) || (length(vec) == 1 && identical(tolower(vec), "all"))) {
     return(valid_elements)
   }
 

--- a/tests/testthat/test-collect_tern_data.R
+++ b/tests/testthat/test-collect_tern_data.R
@@ -124,6 +124,14 @@ test_that(".normalise_datasets returns the full alias set for NULL/'all'", {
   expect_identical(.normalise_datasets("all"), .normalise_datasets(NULL))
 })
 
+test_that(".normalise_vector_elements matches 'all' case-insensitively", {
+  valid <- c("a", "b", "c")
+  expect_identical(.normalise_vector_elements("all", valid, "x"), valid)
+  expect_identical(.normalise_vector_elements("ALL", valid, "x"), valid)
+  expect_identical(.normalise_vector_elements("All", valid, "x"), valid)
+  expect_identical(.normalise_datasets("ALL"), .normalise_datasets(NULL))
+})
+
 test_that(".normalise_datasets deduplicates", {
   expect_identical(
     .normalise_datasets(c("SMIPS", "SMIPS", "ASC")),

--- a/tests/testthat/test-collect_tern_data.R
+++ b/tests/testthat/test-collect_tern_data.R
@@ -132,6 +132,20 @@ test_that(".normalise_vector_elements matches 'all' case-insensitively", {
   expect_identical(.normalise_datasets("ALL"), .normalise_datasets(NULL))
 })
 
+test_that("element matching is case-insensitive and returns the canonical spelling", {
+  # any case in, canonical spelling out (uppercase aliases)
+  expect_identical(.normalise_datasets(c("smips", "asc")), c("SMIPS", "ASC"))
+  expect_identical(.normalise_datasets("SmIpS"), "SMIPS")
+  # mixed-case canonical forms are returned exactly, not the user's case,
+  # so the downstream URL builders receive the spelling TERN expects
+  expect_identical(.normalise_smips_collection("smindex"), "SMindex")
+  expect_identical(.normalise_aet_collection("eta"), "ETa")
+  # an unknown element is still warned about and dropped
+  suppressWarnings(
+    expect_identical(.normalise_datasets(c("smips", "nope")), "SMIPS")
+  )
+})
+
 test_that(".normalise_datasets deduplicates", {
   expect_identical(
     .normalise_datasets(c("SMIPS", "SMIPS", "ASC")),
@@ -460,7 +474,9 @@ test_that(".normalise_soildiv_collection warns and filters invalid variants", {
     )),
     "Invalid"
   )
-  expect_identical(out, "Fungi_NMDS3")
+  # "bacteria_nmds1" now matches case-insensitively (canonical "Bacteria_NMDS1");
+  # "bac_nmds2" is not a real variant, so it is the one dropped with a warning
+  expect_identical(out, c("Bacteria_NMDS1", "Fungi_NMDS3"))
 })
 
 test_that(".normalise_soildiv_collection errors when no valid variants remain", {


### PR DESCRIPTION
## What

`datasets = "all"` expands to every alias, but `datasets = "ALL"` aborted with
"No valid ... aliases" — while every other dataset token is matched
case-insensitively. The mismatch is surprising.

## Fix

`.normalise_vector_elements()` tested the sentinel with `identical(vec, "all")`;
switch to `identical(tolower(vec), "all")` so `"ALL"` / `"All"` behave like
`"all"`. Kept `identical()` rather than `==` to stay NA-safe inside the `if()`.
This helper backs every selector (`datasets`, `depth`, `stat`, and the
per-dataset collection args), so the fix applies uniformly.

## Changes

- `R/collect_tern_data.R` — `.normalise_vector_elements()` sentinel comparison.
- Test: the `"all"` sentinel is matched case-insensitively, asserted directly on
  the shared helper `.normalise_vector_elements()` (`"all"` / `"ALL"` / `"All"`)
  and once through a public selector (`.normalise_datasets("ALL")`), so the
  mechanism is covered at its source rather than at a single call site.

## Verification

`devtools::test()` green; air-clean. No roxygen change, so no `man/` update.
