### PR TITLE
fix(collect): clear message for a reversed date_range

### DIFF
--- a/R/collect_tern_data.R
+++ b/R/collect_tern_data.R
@@ -352,7 +352,15 @@ collect_tern_data <- function(
   }
 
   if (length(date_range) == 2) {
-    dates <- seq(as.Date(date_range[1]), as.Date(date_range[2]), by = "day")
+    start <- as.Date(date_range[1])
+    end <- as.Date(date_range[2])
+    if (start > end) {
+      cli::cli_abort(
+        "{.arg date_range} start {.val {start}} must not be after its end \\
+         {.val {end}}."
+      )
+    }
+    dates <- seq(start, end, by = "day")
   } else {
     dates <- as.Date(date_range)
   }

--- a/tests/testthat/test-collect_tern_data.R
+++ b/tests/testthat/test-collect_tern_data.R
@@ -94,6 +94,17 @@ test_that(".parse_date_range rejects unparseable dates", {
   )
 })
 
+test_that(".parse_date_range rejects a reversed range with a clear message", {
+  expect_error(
+    .parse_date_range(c("2024-01-05", "2024-01-01")),
+    "must not be after its end"
+  )
+  expect_error(
+    .parse_date_range(c(as.Date("2024-01-05"), as.Date("2024-01-01"))),
+    "must not be after its end"
+  )
+})
+
 # .normalise_datasets -------------------------------------------------------
 
 test_that(".normalise_datasets returns the full alias set for NULL/'all'", {


### PR DESCRIPTION
## What

`date_range = c(end, start)` (later date first) reached
`seq(start, end, by = "day")` and failed with R's opaque *"wrong sign in 'by'
argument"*.

## Fix

In `.parse_date_range()`'s length-2 branch, check `start <= end` before the
`seq()` and abort with a message naming both dates if reversed.

## Changes

- `R/collect_tern_data.R` — `start > end` guard in `.parse_date_range()`.
- Test: a reversed range is rejected with the clear message, for **both** a
  `character` and a `Date` input (the guard converts with `as.Date()` first, so
  it covers both), added to the existing `.parse_date_range` test section.

## Verification

`devtools::test()` green; air-clean. (Confirmed cli renders a `Date` cleanly in
the abort message before choosing the wording.) No roxygen change, no `man/`
update.
