### PR TITLE
chore(citation): bump CITATION.cff version to 1.1.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -25,7 +25,7 @@ authors:
     given-names: Max
     email: max.moldovan@adelaide.edu.au
     orcid: "https://orcid.org/0000-0001-9680-8474"
-version: "1.0.0"
+version: "1.1.0"
 license: MIT
 repository-code: "https://github.com/AAGI-AUS/nert"
 url: "https://aagi-aus.github.io/nert/"


### PR DESCRIPTION
## What

`CITATION.cff` still declared `version: "1.0.0"` while `DESCRIPTION` and
`codemeta.json` are both `1.1.0`. Align it.

## Changes

- `CITATION.cff` — `version: "1.1.0"`. (No `date-released` field is present; it
  is set at tag time.)

## Verification

The `.cff` still parses as valid YAML with `version: 1.1.0`. (A pre-commit /
release checklist asserting the version surfaces agree — DESCRIPTION, NEWS,
`CITATION.cff`, `codemeta.json` — would prevent this drift recurring; happy to
add one separately if wanted.)
