### PR TITLE
fix(citation): read the version from DESCRIPTION so CITATION evaluates pre-install

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,3 +1,8 @@
+if (!exists("meta") || is.null(meta)) {
+  meta <- packageDescription("nert")
+}
+vers <- meta$Version
+
 bibentry(
   bibtype = "Manual",
   title = "{nert}: An API Client for TERN Data",
@@ -9,13 +14,13 @@ bibentry(
     person("Max", "Moldovan")
   ),
   year = format(Sys.Date(), "%Y"),
-  note = sprintf("R package version %s", utils::packageVersion("nert")),
+  note = paste("R package version", vers),
   url = "https://aagi-aus.github.io/nert/",
   textVersion = paste0(
     "Sparks AH, Pipattungsakul W, Edson R, Rogers S, Moldovan M (",
     format(Sys.Date(), "%Y"),
     "). nert: An API Client for TERN Data. R package version ",
-    utils::packageVersion("nert"),
+    vers,
     ". https://aagi-aus.github.io/nert/"
   )
 )


### PR DESCRIPTION
## What

`inst/CITATION` read the version via `utils::packageVersion("nert")`, which
fails when the package is not installed — the source of the lone substantive
R CMD check NOTE: *"Reading CITATION file fails ... there is no package called
'nert' when package is not installed."*

## Fix

Use the `meta` object R supplies when it reads the CITATION (the package
`DESCRIPTION`), with a `packageDescription()` fallback so the file still
evaluates standalone, and take the version from `meta$Version`. This is the
standard *Writing R Extensions* pattern.

## Grounding

Confirmed `readCitationFile("inst/CITATION", ...)` reads clean both **with** the
DESCRIPTION `meta` (how R CMD check reads it → the NOTE's exact code path) and
**without** it (the `packageDescription()` fallback). The version resolves to
1.1.0 in the note.

## Changes

- `inst/CITATION` — resolve `vers` from `meta$Version` (fallback
  `packageDescription("nert")`); use it in `note` and `textVersion`.

## Verification

This removes the only substantive incoming-feasibility NOTE; the remaining NOTE
is the benign "New submission".
