### PR TITLE
docs(vignette): use one key name (TERN_API_KEY) across both setup paths

### DIFF
--- a/vignettes/nert.Rmd
+++ b/vignettes/nert.Rmd
@@ -113,16 +113,16 @@ If you prefer a more secure method, you can use the [{keyring}](https://keyring.
     library(keyring)
 
     keyring_create("nert")
-    key_set("NERT_API_KEY", keyring = "nert")
+    key_set("TERN_API_KEY", keyring = "nert")
     ```
 
-    This will create a new keyring called `nert`, with a new key called `NERT_API_KEY`. The function will then prompt you for the actual key value, which you can paste from the TERN website where you copied it earlier. You can then verify that the key was stored as expected by using the `keyring::key_get()` function:
+    This will create a new keyring called `nert`, with a new key called `TERN_API_KEY`. The function will then prompt you for the actual key value, which you can paste from the TERN website where you copied it earlier. You can then verify that the key was stored as expected by using the `keyring::key_get()` function:
 
     ``` r
-    key_get("NERT_API_KEY", keyring = "nert")
+    key_get("TERN_API_KEY", keyring = "nert")
     ```
 
-3.  Finally, you can quickly check that the TERN API key is working with the {nert} package correctly by trying to download a raster. The below R code retrieves the SMIPS "totalbucket" soil moisture data raster for January 1st, 2024 using the `nert::read_smips()` function, and then uses the {terra} package's `terra::extract()` function to get a point value for the soil moisture measurement at the Adelaide CBD (at approximately 138.6007 decimal degrees Easting for the longitude, and -34.9285 decimal degrees Northing for the latitude). Note that we explicitly specify to use the `NERT_API_KEY` we stored in the `nert` keyring by setting the `api_key` argument:
+3.  Finally, you can quickly check that the TERN API key is working with the {nert} package correctly by trying to download a raster. The below R code retrieves the SMIPS "totalbucket" soil moisture data raster for January 1st, 2024 using the `nert::read_smips()` function, and then uses the {terra} package's `terra::extract()` function to get a point value for the soil moisture measurement at the Adelaide CBD (at approximately 138.6007 decimal degrees Easting for the longitude, and -34.9285 decimal degrees Northing for the latitude). Note that we explicitly specify to use the `TERN_API_KEY` we stored in the `nert` keyring by setting the `api_key` argument:
 
     ``` r
     library(nert)
@@ -130,7 +130,7 @@ If you prefer a more secure method, you can use the [{keyring}](https://keyring.
 
     r <- read_smips(
       date = "2024-01-01",
-      api_key = key_get("NERT_API_KEY", keyring = "nert")
+      api_key = key_get("TERN_API_KEY", keyring = "nert")
     )
 
     extract(r, xy = TRUE, data.frame(lon = 138.6007, lat = -34.9285))

--- a/vignettes/nert.Rmd.orig
+++ b/vignettes/nert.Rmd.orig
@@ -122,16 +122,16 @@ If you prefer a more secure method, you can use the [{keyring}](https://keyring.
     library(keyring)
 
     keyring_create("nert")
-    key_set("NERT_API_KEY", keyring = "nert")
+    key_set("TERN_API_KEY", keyring = "nert")
     ```
 
-    This will create a new keyring called `nert`, with a new key called `NERT_API_KEY`. The function will then prompt you for the actual key value, which you can paste from the TERN website where you copied it earlier. You can then verify that the key was stored as expected by using the `keyring::key_get()` function:
+    This will create a new keyring called `nert`, with a new key called `TERN_API_KEY`. The function will then prompt you for the actual key value, which you can paste from the TERN website where you copied it earlier. You can then verify that the key was stored as expected by using the `keyring::key_get()` function:
 
     ```{r, verify-key, eval=FALSE}
-    key_get("NERT_API_KEY", keyring = "nert")
+    key_get("TERN_API_KEY", keyring = "nert")
     ```
 
-3.  Finally, you can quickly check that the TERN API key is working with the {nert} package correctly by trying to download a raster. The below R code retrieves the SMIPS "totalbucket" soil moisture data raster for January 1st, 2024 using the `nert::read_smips()` function, and then uses the {terra} package's `terra::extract()` function to get a point value for the soil moisture measurement at the Adelaide CBD (at approximately 138.6007 decimal degrees Easting for the longitude, and -34.9285 decimal degrees Northing for the latitude). Note that we explicitly specify to use the `NERT_API_KEY` we stored in the `nert` keyring by setting the `api_key` argument:
+3.  Finally, you can quickly check that the TERN API key is working with the {nert} package correctly by trying to download a raster. The below R code retrieves the SMIPS "totalbucket" soil moisture data raster for January 1st, 2024 using the `nert::read_smips()` function, and then uses the {terra} package's `terra::extract()` function to get a point value for the soil moisture measurement at the Adelaide CBD (at approximately 138.6007 decimal degrees Easting for the longitude, and -34.9285 decimal degrees Northing for the latitude). Note that we explicitly specify to use the `TERN_API_KEY` we stored in the `nert` keyring by setting the `api_key` argument:
 
     ```{r, using-keyring, eval=FALSE}
     library(nert)
@@ -139,7 +139,7 @@ If you prefer a more secure method, you can use the [{keyring}](https://keyring.
 
     r <- read_smips(
       date = "2024-01-01",
-      api_key = key_get("NERT_API_KEY", keyring = "nert")
+      api_key = key_get("TERN_API_KEY", keyring = "nert")
     )
 
     extract(r, xy = TRUE, data.frame(lon = 138.6007, lat = -34.9285))


### PR DESCRIPTION
## What

The intro vignette stored the key as `TERN_API_KEY` on the `.Renviron` path but
as `NERT_API_KEY` on the keyring path, while `get_key()` only reads
`TERN_API_KEY`. A reader following the keyring path is then forced to pass
`api_key =` on every call, and the two names are easy to confuse.

## Fix

Standardise the keyring path on `TERN_API_KEY` too, so the same name is used
throughout. The keyring **name** (`keyring = "nert"`) is a separate thing and is
unchanged.

Scoped to the naming inconsistency only. Making `get_key()` consult the keyring
when the env var is unset (so the keyring route is first-class) is a separate
behaviour change and is not included here.

## Changes

- `vignettes/nert.Rmd` and its `.Rmd.orig` source — `NERT_API_KEY` →
  `TERN_API_KEY` in the keyring `key_set` / `key_get` calls and the surrounding
  prose (5 occurrences each).

## Verification

`eval = FALSE` chunks (no network); both `.Rmd` and `.Rmd.orig` updated so the
fix survives a re-precompile. No `NERT_API_KEY` remains anywhere.
