### PR TITLE
test: unit-test dataset handlers directly to reflect true coverage

### DIFF
--- a/tests/testthat/test-read_aet.R
+++ b/tests/testthat/test-read_aet.R
@@ -94,3 +94,37 @@ test_that("read_aet propagates max_tries and initial_delay overrides", {
   expect_identical(captured$max_tries, 7L)
   expect_identical(captured$initial_delay, 4L)
 })
+
+# ---- Direct handler/validator unit tests -----------------------------------
+# read_aet() dispatches through the `.tern_datasets` registry, which holds the
+# validator and handler by reference; exercise them directly to unit-test the
+# date contract and URL construction.
+
+test_that(".validate_aet enforces the date contract directly", {
+  expect_error(.validate_aet(list(), "9fefa68b"), "requires a")
+  expect_error(
+    .validate_aet(list(date = "1980-01-01"), "9fefa68b"),
+    "not available before 1987"
+  )
+  expect_null(.validate_aet(list(date = "2023-06-01"), "9fefa68b"))
+})
+
+test_that(".read_tern_aet floors the date and builds the URL directly", {
+  sink <- .use_mocked_cog()
+  r <- .read_tern_aet("9fefa68b", list(date = "2023-06-15"), KEY, 1L, 0L)
+  # legacy 'month' parameter + pixel_qa collection
+  .read_tern_aet(
+    "9fefa68b", list(month = "2020-01-10", collection = "pixel_qa"), KEY, 1L, 0L
+  )
+  expect_s4_class(r, "SpatRaster")
+  expect_match(
+    sink$urls[[1L]],
+    "/aet/v2_2/2023/2023_06_01/CMRSET_LANDSAT_V2_2_2023_06_01_ETa.vrt",
+    fixed = TRUE
+  )
+  expect_match(
+    sink$urls[[2L]],
+    "CMRSET_LANDSAT_V2_2_2020_01_01_pixel_qa.vrt",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-read_asc.R
+++ b/tests/testthat/test-read_asc.R
@@ -70,3 +70,24 @@ test_that("read_tern ASC rejects unknown collection at arg_match", {
     "must be one of"
   )
 })
+
+# ---- Direct handler unit tests ---------------------------------------------
+# read_asc() dispatches through the `.tern_datasets` registry, which holds the
+# handler by reference; exercise the handler directly to unit-test its argument
+# handling and URL construction.
+
+test_that(".read_tern_asc builds EV/CI URLs and defaults to EV", {
+  sink <- .use_mocked_cog()
+  r <- .read_tern_asc("15728dba", list(collection = "CI"), KEY, 1L, 0L)
+  .read_tern_asc("15728dba", list(), KEY, 1L, 0L)
+  expect_s4_class(r, "SpatRaster")
+  expect_match(sink$urls[[1L]], "ASC_CI_C_P_AU_TRN_N.cog.tif", fixed = TRUE)
+  expect_match(sink$urls[[2L]], "ASC_EV_C_P_AU_TRN_N.cog.tif", fixed = TRUE)
+})
+
+test_that(".read_tern_asc rejects an unknown collection directly", {
+  expect_error(
+    .read_tern_asc("15728dba", list(collection = "ZZ"), KEY, 1L, 0L),
+    "must be one of"
+  )
+})

--- a/tests/testthat/test-read_canopy_height.R
+++ b/tests/testthat/test-read_canopy_height.R
@@ -52,3 +52,18 @@ test_that("read_canopy_height dispatches via the CANOPY alias", {
   read_tern("CANOPY", api_key = KEY)
   expect_match(sink$urls, "best_pick_files_bhLNnun.tif", fixed = TRUE)
 })
+
+# ---- Direct handler unit test ----------------------------------------------
+# read_canopy_height() dispatches through the `.tern_datasets` registry, which
+# holds the handler by reference; exercise the handler directly.
+
+test_that(".read_tern_canopy_height builds the static URL directly", {
+  sink <- .use_mocked_cog()
+  r <- .read_tern_canopy_height("36c98155", list(), KEY, 1L, 0L)
+  expect_s4_class(r, "SpatRaster")
+  expect_match(
+    sink$urls,
+    "CanopyHeightComposite/best_pick_files_bhLNnun.tif",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-read_phenology.R
+++ b/tests/testthat/test-read_phenology.R
@@ -146,3 +146,63 @@ test_that("read_tern dispatches PHENOLOGY alias through to phenology handler", {
   read_tern("PHENOLOGY", year = 2018L, api_key = KEY)
   expect_match(sink$urls, "/phenology_myd13a1/", fixed = TRUE)
 })
+
+# ---- Direct handler/validator unit tests -----------------------------------
+# The dataset handlers and validators are dispatched through the
+# `.tern_datasets` registry, which holds them by reference; exercising them
+# directly (rather than only end-to-end through `read_tern()`) unit-tests the
+# validation and URL-construction logic in isolation.
+
+test_that(".validate_phenology enforces the year contract directly", {
+  expect_error(.validate_phenology(list(), "2bb0c81a"), "requires a")
+  expect_error(.validate_phenology(list(year = 2002L), "2bb0c81a"), "2003")
+  expect_error(.validate_phenology(list(year = 2019L), "2bb0c81a"), "2018")
+  expect_error(
+    .validate_phenology(list(year = c(2018L, 2017L)), "2bb0c81a"),
+    "single value"
+  )
+  expect_error(.validate_phenology(list(year = 2018.5), "2bb0c81a"), "integer")
+  expect_null(.validate_phenology(list(year = 2018L), "2bb0c81a"))
+})
+
+test_that(".read_tern_phenology builds the documented URL for each metric", {
+  sink <- .use_mocked_cog()
+  r <- .read_tern_phenology(
+    did = "2bb0c81a",
+    dots = list(year = 2018L, season = 2L, collection = "EVIP"),
+    api_key = KEY,
+    max_tries = 1L,
+    initial_delay = 0L
+  )
+  expect_s4_class(r, "SpatRaster")
+  expect_match(
+    sink$urls,
+    paste0(
+      "/phenology_myd13a1/7_Peak_EVI_value_of_the_growing_season/",
+      "Peak_EVI_2018_Season2.tif"
+    ),
+    fixed = TRUE
+  )
+})
+
+test_that(".read_tern_phenology defaults season/collection and checks season", {
+  sink <- .use_mocked_cog()
+  .read_tern_phenology("2bb0c81a", list(year = 2018L), KEY, 1L, 0L)
+  expect_match(sink$urls, "SGS_2018_Season1.tif", fixed = TRUE)
+  expect_error(
+    .read_tern_phenology("2bb0c81a", list(year = 2018L, season = 3L), KEY, 1L, 0L),
+    "must be 1 or 2"
+  )
+  expect_error(
+    .read_tern_phenology(
+      "2bb0c81a", list(year = 2018L, season = c(1L, 2L)), KEY, 1L, 0L
+    ),
+    "single value"
+  )
+  expect_error(
+    .read_tern_phenology(
+      "2bb0c81a", list(year = 2018L, collection = "XYZ"), KEY, 1L, 0L
+    ),
+    "must be one of"
+  )
+})

--- a/tests/testthat/test-read_slga.R
+++ b/tests/testthat/test-read_slga.R
@@ -255,3 +255,40 @@ test_that("read_tern dispatches the slga_cly alias through to CLY", {
     fixed = TRUE
   )
 })
+
+# ---- Direct handler unit tests ---------------------------------------------
+# The SLGA handler is dispatched through the `.tern_datasets` registry (built
+# from `.slga_config`), which holds it by reference; exercise it directly to
+# unit-test depth/statistic handling and per-attribute URL construction.
+
+test_that(".read_tern_slga builds URLs from the config directly", {
+  sink <- .use_mocked_cog()
+  # AWC, explicit depth + 95th-percentile statistic
+  r <- .read_tern_slga(
+    "482301c2", list(depth = "005_015", collection = "95"), KEY, 1L, 0L
+  )
+  # PHC uses a distinct dir/suffix/date and default depth/EV
+  .read_tern_slga("258afc98", list(), KEY, 1L, 0L)
+  expect_s4_class(r, "SpatRaster")
+  expect_match(
+    sink$urls[[1L]],
+    "SoilAndLandscapeGrid/AWC/v2/AWC_005_015_95_N_P_AU_TRN_N_20210614.tif",
+    fixed = TRUE
+  )
+  expect_match(
+    sink$urls[[2L]],
+    "SoilAndLandscapeGrid/pHc/v2/PHC_000_005_EV_N_P_AU_NAT_C_20210913.tif",
+    fixed = TRUE
+  )
+})
+
+test_that(".read_tern_slga rejects bad depth/statistic directly", {
+  expect_error(
+    .read_tern_slga("482301c2", list(depth = "999_999"), KEY, 1L, 0L),
+    "must be one of"
+  )
+  expect_error(
+    .read_tern_slga("482301c2", list(collection = "ZZ"), KEY, 1L, 0L),
+    "must be one of"
+  )
+})

--- a/tests/testthat/test-read_smips.R
+++ b/tests/testthat/test-read_smips.R
@@ -1,0 +1,72 @@
+# Offline behaviour tests for read_smips() and its internal handler.
+# Mocking via helper-mocks.R; no network I/O.
+
+KEY <- "test-key-0000"
+
+# ---- End-to-end read_smips() -----------------------------------------------
+
+test_that("read_smips builds the documented totalbucket URL", {
+  sink <- .use_mocked_cog()
+  r <- read_smips(date = "2024-01-15", api_key = KEY)
+  expect_s4_class(r, "SpatRaster")
+  expect_match(
+    sink$urls,
+    "/smips/v1_0/totalbucket/2024/smips_totalbucket_mm_20240115.tif",
+    fixed = TRUE
+  )
+})
+
+test_that("read_smips SMindex collection maps to the smi_perc filename", {
+  sink <- .use_mocked_cog()
+  read_smips(date = "2024-01-15", collection = "SMindex", api_key = KEY)
+  expect_match(
+    sink$urls,
+    "/smips/v1_0/SMindex/2024/smips_smi_perc_20240115.tif",
+    fixed = TRUE
+  )
+})
+
+test_that("read_smips rejects a date before the collection's availability", {
+  # totalbucket/SMindex are available from 2005; earlier dates are refused.
+  expect_error(
+    read_smips(date = "1990-01-01", api_key = KEY),
+    "not generally available"
+  )
+})
+
+test_that("read_smips rejects an unknown collection", {
+  expect_error(
+    read_smips(date = "2024-01-15", collection = "nope", api_key = KEY),
+    "must be one of"
+  )
+})
+
+# ---- Direct handler/validator unit tests -----------------------------------
+# read_smips() dispatches through the `.tern_datasets` registry, which holds the
+# validator and handler by reference; exercise them directly to unit-test the
+# date contract and per-collection URL construction.
+
+test_that(".validate_smips requires a date directly", {
+  expect_error(.validate_smips(list(), "d1995ee8"), "requires a")
+  expect_null(.validate_smips(list(date = "2024-01-15"), "d1995ee8"))
+})
+
+test_that(".read_tern_smips builds per-collection URLs directly", {
+  sink <- .use_mocked_cog()
+  r <- .read_tern_smips(
+    "d1995ee8", list(date = "2020-06-30", collection = "bucket1"), KEY, 1L, 0L
+  )
+  # legacy 'day' parameter + default totalbucket collection
+  .read_tern_smips("d1995ee8", list(day = "2024-02-01"), KEY, 1L, 0L)
+  expect_s4_class(r, "SpatRaster")
+  expect_match(
+    sink$urls[[1L]],
+    "/smips/v1_0/bucket1/2020/smips_bucket1_mm_20200630.tif",
+    fixed = TRUE
+  )
+  expect_match(
+    sink$urls[[2L]],
+    "/smips/v1_0/totalbucket/2024/smips_totalbucket_mm_20240201.tif",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-read_soil_diversity.R
+++ b/tests/testthat/test-read_soil_diversity.R
@@ -69,3 +69,40 @@ test_that("axis is coerced to integer", {
   read_soil_diversity(axis = 2, api_key = KEY) # numeric, not integer
   expect_match(sink$urls, "_2_", fixed = TRUE)
 })
+
+# ---- Direct handler unit tests ---------------------------------------------
+# read_soil_diversity() dispatches through the `.tern_datasets` registry, which
+# holds the handler by reference; exercising the handler directly unit-tests its
+# argument handling and URL construction in isolation.
+
+test_that(".read_tern_soil_diversity builds URLs and defaults its args", {
+  sink <- .use_mocked_cog()
+  r <- .read_tern_soil_diversity(
+    "4a428d52", list(collection = "Fungi", axis = 3L), KEY, 1L, 0L
+  )
+  .read_tern_soil_diversity("4a428d52", list(), KEY, 1L, 0L)
+  expect_s4_class(r, "SpatRaster")
+  expect_match(
+    sink$urls[[1L]],
+    "Other/SoilBetaDiversity/NMDS_Fungi_3_Fungi_pred.tif",
+    fixed = TRUE
+  )
+  expect_match(sink$urls[[2L]], "NMDS_Bacteria_1_Bacteria_pred.tif", fixed = TRUE)
+})
+
+test_that(".read_tern_soil_diversity rejects bad axis/collection directly", {
+  expect_error(
+    .read_tern_soil_diversity("4a428d52", list(axis = 4L), KEY, 1L, 0L),
+    "must be 1, 2, or 3"
+  )
+  expect_error(
+    .read_tern_soil_diversity("4a428d52", list(axis = c(1L, 2L)), KEY, 1L, 0L),
+    "must be a single value"
+  )
+  expect_error(
+    .read_tern_soil_diversity(
+      "4a428d52", list(collection = "Archaea"), KEY, 1L, 0L
+    ),
+    "must be one of"
+  )
+})


### PR DESCRIPTION
## What

The dataset handlers (`.read_tern_*`) and validators (`.validate_*`) report low
key-less coverage (11-40%) even though the end-to-end mocked tests exercise them.
The cause is a coverage-tooling blind spot, not missing tests.

`read_tern()` dispatches through the `.tern_datasets` registry (`R/read_tern.R`),
which holds each handler / validator **by reference**, captured at package load
time. Coverage instrumentation replaces the package's namespace bindings, so the
registry-dispatched calls (`entry$read(...)`, `entry$validate(...)`) run the
original, un-instrumented function objects. They execute (the mocked tests pass)
but read as uncovered.

## Change

Add direct unit tests that call each `.validate_*` / `.read_tern_*` by name,
which resolves the instrumented binding so coverage is credited. Each test
asserts the documented `/vsicurl` URL for the argument variants and exercises the
validation branches. Adds a dedicated `test-read_smips.R` (there was none).

This is a measurement-accuracy change plus isolated unit coverage of the
handlers' argument handling. **No package code is changed.**

## Effect (key-less coverage, as CI measures it)

Every `read_*()` handler file reaches 100%. Package total 56.5% -> 74.8% on this
PR alone; ~99.8% together with the companion edge-branch PR.

Single-concern, off current `main`. Part of the rOpenSci-readiness work.
