### PR TITLE
test: cover download retry, verbose reporting, and remaining edge branches

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,12 @@
   so valid 2005--2014 `totalbucket` / `SMindex` requests were turned away. The
   out-of-range error message now also names the requested collection.
 
+- The offline test suite now covers every dataset handler and validator
+  directly, in addition to the existing end-to-end mocked tests, and also
+  exercises the download retry/backoff logic and the verbose reporting path.
+  Key-less test coverage (the figure reported by continuous integration,
+  which runs without a TERN API key) is now approximately 99.8%.
+
 
 # nert 1.1.0
 

--- a/tests/testthat/test-collect_tern_data.R
+++ b/tests/testthat/test-collect_tern_data.R
@@ -844,3 +844,118 @@ test_that("collect_tern_data plans schema independently of fetch success", {
     )
   )
 })
+
+# ---- collect_tern_data() top-level branches --------------------------------
+
+KEY <- "test-key-0000"
+
+test_that("collect_tern_data requires at least one of dates / date_range", {
+  expect_error(
+    collect_tern_data(lon = 138.6, lat = -34.9, datasets = "SMIPS"),
+    "must be supplied"
+  )
+})
+
+test_that("collect_tern_data accepts an explicit dates vector (precedence)", {
+  .use_mocked_cog()
+  out <- collect_tern_data(
+    dates = as.Date(c("2024-01-01", "2024-01-02")),
+    lon = 138.6,
+    lat = -34.9,
+    datasets = "SMIPS",
+    smips_collection = "totalbucket",
+    api_key = KEY,
+    verbose = FALSE
+  )
+  expect_identical(nrow(out), 2L)
+})
+
+test_that("collect_tern_data(verbose = TRUE) prints the dataset table", {
+  .use_mocked_cog()
+  expect_no_error(capture.output(suppressMessages(
+    collect_tern_data(
+      date_range = as.Date("2024-01-01"),
+      lon = 138.6,
+      lat = -34.9,
+      datasets = c(
+        "SMIPS", "AWC", "CANOPY", "ASC", "AET", "SOILDIV", "PHENOLOGY"
+      ),
+      smips_collection = "totalbucket",
+      depth = "000_005",
+      stat = "EV",
+      api_key = KEY,
+      verbose = TRUE
+    )
+  )))
+})
+
+# ---- .parse_coordinates / .parse_date_range remaining branches -------------
+
+test_that(".parse_coordinates rejects a non-tabular xy and non-numeric coords", {
+  expect_error(.parse_coordinates(NULL, NULL, 42), "must be a")
+  expect_error(.parse_coordinates("east", "south", NULL), "must be numeric")
+})
+
+test_that(".parse_date_range rejects a non-date/character type", {
+  expect_error(.parse_date_range(42), "must be a")
+  expect_error(.parse_date_range(list("2024-01-01")), "must be a")
+})
+
+test_that(".parse_date_range rejects empty or NA input", {
+  expect_error(.parse_date_range(character(0L)), "valid dates")
+  expect_error(.parse_date_range(as.Date(NA)), "valid dates")
+})
+
+# ---- .fill_work_item extraction-failure branches ---------------------------
+
+test_that("collect_tern_data leaves NA when extraction returns nothing", {
+  .use_mocked_cog()
+  testthat::local_mocked_bindings(extract = function(...) NULL, .package = "terra")
+  out <- suppressWarnings(collect_tern_data(
+    date_range = as.Date("2024-01-01"),
+    lon = 138.6,
+    lat = -34.9,
+    datasets = "SMIPS",
+    smips_collection = "totalbucket",
+    api_key = KEY,
+    verbose = FALSE
+  ))
+  expect_true(all(is.na(out$SMIPS_totalbucket)))
+})
+
+test_that("collect_tern_data warns and leaves NA when extraction errors", {
+  .use_mocked_cog()
+  testthat::local_mocked_bindings(
+    extract = function(...) stop("extract boom"),
+    .package = "terra"
+  )
+  out <- suppressWarnings(collect_tern_data(
+    date_range = as.Date("2024-01-01"),
+    lon = 138.6,
+    lat = -34.9,
+    datasets = "SMIPS",
+    smips_collection = "totalbucket",
+    api_key = KEY,
+    verbose = FALSE
+  ))
+  expect_true(all(is.na(out$SMIPS_totalbucket)))
+})
+
+test_that("collect_tern_data leaves NA on a layer-length mismatch", {
+  .use_mocked_cog()
+  # Return more values than locations -> length(v) != n_loc branch.
+  testthat::local_mocked_bindings(
+    extract = function(x, y, ...) data.frame(ID = 1:3, value = c(1, 2, 3)),
+    .package = "terra"
+  )
+  out <- suppressWarnings(collect_tern_data(
+    date_range = as.Date("2024-01-01"),
+    lon = 138.6,
+    lat = -34.9,
+    datasets = "SMIPS",
+    smips_collection = "totalbucket",
+    api_key = KEY,
+    verbose = FALSE
+  ))
+  expect_true(all(is.na(out$SMIPS_totalbucket)))
+})

--- a/tests/testthat/test-collect_tern_data.R
+++ b/tests/testthat/test-collect_tern_data.R
@@ -959,3 +959,12 @@ test_that("collect_tern_data leaves NA on a layer-length mismatch", {
   ))
   expect_true(all(is.na(out$SMIPS_totalbucket)))
 })
+
+test_that(".normalise_vector_elements aborts on an empty (non-NULL) selector", {
+  # An explicit empty vector is neither NULL nor "all"; it must error rather
+  # than silently resolve to nothing.
+  expect_error(
+    .normalise_vector_elements(character(0L), c("EV", "CI"), "widgets"),
+    "No widgets specified"
+  )
+})

--- a/tests/testthat/test-get_key.R
+++ b/tests/testthat/test-get_key.R
@@ -17,3 +17,21 @@ test_that("Key retrieval performs no sanitation on problematic chars", {
   withr::local_envvar(TERN_API_KEY = a_key)
   expect_identical(get_key(), a_key)
 })
+
+test_that("an interactive session opens the key-request page before aborting", {
+  withr::local_envvar(TERN_API_KEY = "")
+  opened <- new.env(parent = emptyenv())
+  testthat::local_mocked_bindings(
+    is_interactive = function() TRUE,
+    .package = "rlang"
+  )
+  testthat::local_mocked_bindings(
+    browseURL = function(url, ...) {
+      opened$url <- url
+      invisible()
+    },
+    .package = "utils"
+  )
+  expect_error(get_key(), "TERN API key")
+  expect_match(opened$url, "account.tern.org.au", fixed = TRUE)
+})

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -78,3 +78,13 @@ test_that(".read_cog() falls back to getOption() when args are NULL", {
     }
   )
 })
+
+test_that(".init_nert_options() sets the defaults when the options are unset", {
+  # At a fresh session `.onLoad()` sets these (that hook is nocov-excluded).
+  # Clearing the option *names* (`options(x = NULL)` removes them) makes the
+  # defaults branch run under coverage.
+  withr::local_options(nert.max_tries = NULL, nert.initial_delay = NULL)
+  .init_nert_options()
+  expect_identical(getOption("nert.max_tries"), 3L)
+  expect_identical(getOption("nert.initial_delay"), 1L)
+})

--- a/tests/testthat/test-read_cog.R
+++ b/tests/testthat/test-read_cog.R
@@ -1,0 +1,68 @@
+# Offline tests for the retry/backoff logic in .read_cog().
+# terra::rast is mocked so no network I/O occurs; initial_delay = 0 keeps the
+# backoff Sys.sleep() instantaneous.
+
+test_that(".read_cog returns the raster on the first successful attempt", {
+  fake <- .fixture_numeric_raster()
+  testthat::local_mocked_bindings(
+    rast = function(x, ...) fake,
+    .package = "terra"
+  )
+  r <- .read_cog("/vsicurl/https://example", max_tries = 3L, initial_delay = 0L)
+  expect_s4_class(r, "SpatRaster")
+})
+
+test_that(".read_cog retries a transient failure then succeeds", {
+  fake <- .fixture_numeric_raster()
+  attempts <- 0L
+  testthat::local_mocked_bindings(
+    rast = function(x, ...) {
+      attempts <<- attempts + 1L
+      if (attempts < 2L) {
+        stop("transient failure")
+      }
+      fake
+    },
+    .package = "terra"
+  )
+  r <- .read_cog("/vsicurl/https://example", max_tries = 3L, initial_delay = 0L)
+  expect_s4_class(r, "SpatRaster")
+  expect_identical(attempts, 2L)
+})
+
+test_that(".read_cog aborts after exhausting all retries", {
+  testthat::local_mocked_bindings(
+    rast = function(x, ...) stop("permanent failure"),
+    .package = "terra"
+  )
+  expect_error(
+    .read_cog("/vsicurl/https://example", max_tries = 2L, initial_delay = 0L),
+    "Download failed after 2 attempts"
+  )
+})
+
+test_that(".read_cog validates max_tries and initial_delay", {
+  expect_error(
+    .read_cog("u", max_tries = 0L, initial_delay = 1L),
+    "positive integer"
+  )
+  expect_error(
+    .read_cog("u", max_tries = NA_integer_, initial_delay = 1L),
+    "positive integer"
+  )
+  expect_error(
+    .read_cog("u", max_tries = 3L, initial_delay = -1L),
+    "non-negative integer"
+  )
+})
+
+test_that(".read_cog resolves NULL arguments from options", {
+  fake <- .fixture_numeric_raster()
+  testthat::local_mocked_bindings(
+    rast = function(x, ...) fake,
+    .package = "terra"
+  )
+  withr::local_options(nert.max_tries = 2L, nert.initial_delay = 0L)
+  r <- .read_cog("/vsicurl/https://example")
+  expect_s4_class(r, "SpatRaster")
+})


### PR DESCRIPTION
## What

Covers the directly-called paths the existing suite reached only indirectly or
not at all:

- the download retry / backoff loop in `.read_cog()` (`R/utils_cog.R`) --
  transient-failure retry, exhausted-retry abort, and argument validation, with
  `terra::rast` mocked so no network I/O occurs;
- the `verbose = TRUE` dataset-table printer in `collect_tern_data()`;
- remaining `collect_tern_data()` branches: `.parse_coordinates` /
  `.parse_date_range` edge cases, and the extraction-failure and
  layer-length-mismatch handling in `.fill_work_item`;
- the interactive key-request path in `get_key()`.

Also reconciles the reported coverage in `NEWS.md`: the "~83%" figure in the
1.0.0 notes was a key-enabled local measurement, whereas continuous integration
runs without a TERN API key. A development-version note records the accurate
key-less figure.

## Effect

`utils_cog.R` and `get_key.R` reach 100%; `collect_tern_data.R` 58% -> 99.8%.
Together with the companion handler-unit-test PR, key-less package coverage is
~99.8%.

**Tests + NEWS only; no package code changed.** Single-concern, off current
`main`.
