### PR TITLE
chore: transfer maintainer (cre) role to Max Moldovan

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,9 +7,9 @@ Authors@R: c(
     person("Wasin", "Pipattungsakul", , "wasin.pipattungsakul@adelaide.edu.au", role = "aut"),
     person("Russell", "Edson", , "russell.edson@adelaide.edu.au", role = "aut",
            comment = c(ORCID = "0000-0002-4607-5396")),
-    person("Sam", "Rogers", , "sam.rogers@adelaide.edu.au", role = c("cre", "aut"),
+    person("Sam", "Rogers", , "sam.rogers@adelaide.edu.au", role = "aut",
            comment = c(ORCID = "0000-0002-8147-1239")),
-    person("Max", "Moldovan", , "max.moldovan@adelaide.edu.au", role = "aut",
+    person("Max", "Moldovan", , "max.moldovan@adelaide.edu.au", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0001-9680-8474")),
     person("Grains Research and Development Corporation", role = c("fnd", "cph"),
            comment = c("GRDC Project CUR2210-005OPX (AAGI-CU), UOA2301-005OPX (AAGI-AU)", ROR = "02xwr1996"))

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -34,8 +34,8 @@ time on issues and PRs is typically within two to four weeks.
 
 | Role | Person | GitHub |
 |---|---|---|
-| Maintainer (`cre`) | Sam Rogers | @rogerssam |
-| Authors (`aut`) | Adam Sparks, Wasin Pipattungsakul, Russell Edson, Max Moldovan | @adamhsparks, @wvjgsuhp, @RussellAndrewEdson, @max578 |
+| Maintainer (`cre`) | Max Moldovan | @max578 |
+| Authors (`aut`) | Adam Sparks, Wasin Pipattungsakul, Russell Edson, Sam Rogers | @adamhsparks, @wvjgsuhp, @RussellAndrewEdson, @rogerssam |
 | Funding | GRDC project CUR2210-005OPX | — |
 
 If response is needed sooner than two weeks for a specific question, a

--- a/codemeta.json
+++ b/codemeta.json
@@ -66,10 +66,10 @@
   "maintainer": [
     {
       "@type": "Person",
-      "givenName": "Sam",
-      "familyName": "Rogers",
-      "email": "sam.rogers@adelaide.edu.au",
-      "@id": "https://orcid.org/0000-0002-8147-1239"
+      "givenName": "Max",
+      "familyName": "Moldovan",
+      "email": "max.moldovan@adelaide.edu.au",
+      "@id": "https://orcid.org/0000-0001-9680-8474"
     }
   ],
   "softwareSuggestions": [

--- a/man/nert-package.Rd
+++ b/man/nert-package.Rd
@@ -18,15 +18,15 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Sam Rogers \email{sam.rogers@adelaide.edu.au} (\href{https://orcid.org/0000-0002-8147-1239}{ORCID})
+\strong{Maintainer}: Max Moldovan \email{max.moldovan@adelaide.edu.au} (\href{https://orcid.org/0000-0001-9680-8474}{ORCID})
 
 Authors:
 \itemize{
-  \item Sam Rogers \email{sam.rogers@adelaide.edu.au} (\href{https://orcid.org/0000-0002-8147-1239}{ORCID})
+  \item Max Moldovan \email{max.moldovan@adelaide.edu.au} (\href{https://orcid.org/0000-0001-9680-8474}{ORCID})
   \item Adam H. Sparks \email{adamhsparks@gmail.com} (\href{https://orcid.org/0000-0002-0061-8359}{ORCID})
   \item Wasin Pipattungsakul \email{wasin.pipattungsakul@adelaide.edu.au}
   \item Russell Edson \email{russell.edson@adelaide.edu.au} (\href{https://orcid.org/0000-0002-4607-5396}{ORCID})
-  \item Max Moldovan \email{max.moldovan@adelaide.edu.au} (\href{https://orcid.org/0000-0001-9680-8474}{ORCID})
+  \item Sam Rogers \email{sam.rogers@adelaide.edu.au} (\href{https://orcid.org/0000-0002-8147-1239}{ORCID})
 }
 
 Other contributors:


### PR DESCRIPTION
## What

Sets Max Moldovan as the package maintainer (`cre`), with Sam Rogers
continuing as an author (`aut`). No other authorship changes.

## Why

Max will be handling the upcoming rOpenSci submission, so the
`cre`/Maintainer role and contact point should sit with him ahead of
that process.

## Changes

The maintainer designation is synced across every artefact that encodes
it, from the single source of truth in `DESCRIPTION`:

- `DESCRIPTION` — `Authors@R`: Max `c("cre", "aut")`, Sam `"aut"`
- `man/nert-package.Rd` — `\author` Maintainer line and author ordering
- `codemeta.json` — `maintainer` block
- `SUPPORT.md` — maintenance-capacity table

Deliberately left unchanged:

- `CITATION.cff` carries no maintainer or contact field and the author
  list is unchanged, so it needs no edit.
- `.github/CODEOWNERS` (`* @rogerssam`) is untouched. PR-review routing
  is a separate repository-access decision, happy to update it in a
  follow-up if that is wanted.

The copyright holder and funder (`cph`, `fnd`) remain GRDC, unaffected
by this change.

## Verification

- `DESCRIPTION` parses with exactly one `cre`, and R derives
  `Maintainer: Max Moldovan <max.moldovan@adelaide.edu.au>`.
- `codemeta.json` is valid JSON with the maintainer block pointing to
  Max, and `CITATION.cff` remains valid YAML.
- `man/nert-package.Rd` parses cleanly, and no file still names a
  different maintainer.

CI will run the full R-CMD-check matrix on this PR.
